### PR TITLE
fix snapcraft build failing because of UTF-8 error

### DIFF
--- a/docker-files-for-Gitlab-CI-rust/cross/snapcraft/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/cross/snapcraft/Dockerfile
@@ -5,3 +5,5 @@ WORKDIR /build
 RUN apt-get update && \
         apt-get install -y --force-yes --no-install-recommends \
         snapcraft git snapd
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8


### PR DESCRIPTION
fixes https://gitlab.parity.io/parity/parity/-/jobs/59791/raw

Traceback (most recent call last):
  File "/usr/bin/snapcraft", line 32, in <module>
    obj=dict(project=snapcraft.ProjectOptions()))
  File "/usr/lib/python3/dist-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/click/core.py", line 675, in main
    _verify_python3_env()
  File "/usr/lib/python3/dist-packages/click/_unicodefun.py", line 119, in _verify_python3_env
    'mitigation steps.' + extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Either run this under Python 2 or consult http://click.pocoo.org/python3/ for mitigation steps.

This system supports the C.UTF-8 locale which is recommended.
You might be able to resolve your issue by exporting the
following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8