### PR TITLE
Default to Stable

### DIFF
--- a/get-parity.sh
+++ b/get-parity.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Copyright 2017 Parity Technologies (UK) Ltd.
-RELEASE="beta"
+RELEASE="stable"
 ARCH=$(uname -m)
 VANITY_SERVICE_URL="https://vanity-service.parity.io/parity-binaries?architecture=$ARCH&format=markdown"
 


### PR DESCRIPTION
1.7.5 is the current recommended version and it is "stable"

Also, I'm not sure why it defaults to "beta" in the first place. Normal users should always be on a stable branch...