### PR TITLE
Use beta over beta-release.

### DIFF
--- a/get-parity.sh
+++ b/get-parity.sh
@@ -30,11 +30,7 @@ check_os() {
 
 get_package() {
 
-	if [ "$RELEASE" = "beta" ]; then
-		LOOKUP_URL="$VANITY_SERVICE_URL&os=$PKG&version=beta-release"
-	else
-		LOOKUP_URL="$VANITY_SERVICE_URL&os=$PKG&version=$RELEASE"
-	fi
+	LOOKUP_URL="$VANITY_SERVICE_URL&os=$PKG&version=$RELEASE"
 
 	if [ "$PKG" = "debian" ] ; then
 		MD=$(curl ${LOOKUP_URL} | grep amd64 )


### PR DESCRIPTION
beta-release points to 1.8.2 and beta to 1.8.4. let's drop whatever beta-release is meant to be.

Closes https://github.com/paritytech/parity/issues/7293