### PR TITLE
don't dist-upgrade snapcraft's docker image

### DIFF
--- a/docker-files-for-Gitlab-CI-rust/cross/snapcraft/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/cross/snapcraft/Dockerfile
@@ -4,19 +4,19 @@ WORKDIR /build
 # install tools and dependencies
 RUN apt-get update && \
     apt-get upgrade --yes && \
-	  apt-get install --yes --no-install-recommends \
+    apt-get install --yes --no-install-recommends \
       snapcraft \
-			snapd \
-			git \
-			ca-certificates \
-			file \
-			python \
-			python-pip \
-			zip \
-			curl \
-			expect \
-			nodejs && \
-	  apt-get clean
+      snapd \
+      git \
+      ca-certificates \
+      file \
+      python \
+      python-pip \
+      zip \
+      curl \
+      expect \
+      nodejs && \
+    apt-get clean
 # install AWS CLI
 RUN pip install awscli
 ENV LC_ALL=C.UTF-8

--- a/docker-files-for-Gitlab-CI-rust/cross/snapcraft/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/cross/snapcraft/Dockerfile
@@ -3,14 +3,21 @@ MAINTAINER Parity Technologies <devops@parity.io>
 WORKDIR /build
 # install tools and dependencies
 RUN apt-get update && \
-    apt-get dist-upgrade --yes && \
+    apt-get upgrade --yes && \
 	  apt-get install --yes --no-install-recommends \
-    snapcraft git snapd ca-certificates file python zip curl expect nodejs && \
-	  apt-get autoclean --yes && \
-	  apt-get clean --yes
+      snapcraft \
+			snapd \
+			git \
+			ca-certificates \
+			file \
+			python \
+			python-pip \
+			zip \
+			curl \
+			expect \
+			nodejs && \
+	  apt-get clean
 # install AWS CLI
-RUN curl -O https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
-    pip install awscli
+RUN pip install awscli
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
I'm not exactly sure whether this helps but dist-upgrading snapcraft in the image creation seems to pull an incompatible version of snapcraft.

https://packages.ubuntu.com/search?keywords=snapcraft
should fix https://gitlab.parity.io/parity/parity-ethereum/-/jobs/97863

any comments welcome