### PR TITLE
Add clang dependency to docker build container

### DIFF
--- a/docker-files-for-Gitlab-CI-rust/rustup/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/rustup/Dockerfile
@@ -8,7 +8,7 @@ RUN apt -y update && \
   apt install -y --no-install-recommends \
 	software-properties-common curl git file binutils binutils-dev snapcraft \
 	make cmake ca-certificates g++ zip dpkg-dev python rhash rpm openssl gettext\
-  build-essential pkg-config libssl-dev libudev-dev ruby-dev time
+  	build-essential clang libclang-dev pkg-config libssl-dev libudev-dev ruby-dev time
 
 #install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - && \


### PR DESCRIPTION
In order to [build substrate, we now need clang to parse headers of the internal rocksdb](https://github.com/paritytech/substrate/pull/1207). This adds the missing dependencies (tested locally) [so that our CI](https://gitlab.parity.io/parity/substrate/-/jobs/111558) passes again.

A review, merge and push of the `nightly`-tagged container would be highly appreciated!