### PR TITLE
get-substrate.sh: force the (re)installation of subkey and substrate

### DIFF
--- a/get-substrate.sh
+++ b/get-substrate.sh
@@ -55,8 +55,8 @@ if ! which rustup >/dev/null 2>&1; then
 else
 	rustup update
 fi
-cargo install --git https://github.com/paritytech/substrate subkey
-cargo install --git https://github.com/paritytech/substrate substrate
+cargo install --force --git https://github.com/paritytech/substrate subkey
+cargo install --force --git https://github.com/paritytech/substrate substrate
 
 f=`mktemp -d`
 git clone https://github.com/paritytech/substrate-up $f


### PR DESCRIPTION
Hi

To pull in the latest beta release and also the improvements to `substrate-up` I executed `curl https://getsubstrate.io -sSf | bash` again.

Everything went fine, except that `subkey` and `substrate` where not updated because I already had them installed before.

```sh
   Updating git repository `https://github.com/paritytech/substrate`
  Installing subkey v0.1.0 (https://github.com/paritytech/substrate#9dfe0066)   
error: binary `subkey` already exists in destination as part of `subkey v0.1.0 (https://github.com/paritytech/substrate#0370a157)`
Add --force to overwrite
    Updating git repository `https://github.com/paritytech/substrate`
  Installing substrate v0.9.0 (https://github.com/paritytech/substrate#9dfe0066)
error: binary `substrate` already exists in destination as part of `substrate v0.1.0 (https://github.com/paritytech/substrate#0370a157)`
Add --force to overwrite
```
To make updates more smoothly, I propose we use `--force` to ensure the latest version of subkey and substrate is installed. Sadly `cargo install` has no `--update` flag ... 

Cheers,
Fabian