### PR TITLE
Xenial rust autoupdate

### DIFF
--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -28,30 +28,31 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 	apt-get -y update && apt-get install -y --no-install-recommends \
 	nodejs yarn
 
-# install rustup
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
-	cargo install \
-	cargo-audit \
-	sccache
-
 RUN mkdir /parity-ethereum
 WORKDIR /parity-ethereum
 
-# pre-download repositories
-RUN git clone https://github.com/paritytech/parity-ethereum.git . && \
-	git submodule update --init --recursive
 
-	# rustup directory
-ENV PATH=/root/.cargo/bin:$PATH \
-	# compiler ENV
-	CC=gcc \
+# install rustup
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# rustup directory
+ENV PATH=/root/.cargo/bin:$PATH
+
+RUN cargo install cargo-audit sccache
+
+# compiler ENV
+ENV CC=gcc \
 	CXX=g++ \
 	CARGO_TARGET=x86_64-unknown-linux-gnu \
 	CARGO_HOME=/parity-ethereum/.cargo/ \
-	# cache handler
+# cache handler
 	RUSTC_WRAPPER=sccache \
 	SCCACHE_DIR=$CARGO_HOME/sccache \
-	# show backtraces
+# show backtraces
 	RUST_BACKTRACE=1
+
+# pre-download repositories
+RUN git clone https://github.com/paritytech/parity-ethereum.git . && \
+        git submodule update --init --recursive
 
 VOLUME /parity-ethereum/artifacts $CARGO_HOME

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -1,14 +1,16 @@
 # triggers image autoupdate with the new Rust release
 FROM rust:slim as notifier
+
 # temporary support of 16.04 with its Clib
 FROM ubuntu:xenial as builder
-LABEL maintainer="Parity Technologies <devops-team@parity.io>"
-LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name="parity/rust-parity-ethereum-build" \
-      org.label-schema.description="This is for CI build stage for Parity Ethereum linux binary." \
-      org.label-schema.url="https://gitlab.com/paritytech/scripts/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci" \
-      org.label-schema.schema-version="1.0"
 
+# metadata
+LABEL maintainer="devops-team@parity.io" \
+	vendor="Parity Technologies" \
+    name="parity/rust-parity-ethereum-build" \
+    description="This is for CI build stage for Parity Ethereum linux binary." \
+    vcs-url="https://gitlab.com/paritytech/scripts/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci" \
+	url="https://gitlab.com/paritytech"
 
 # install tools and dependencies
 RUN apt-get -y update && \
@@ -16,12 +18,10 @@ RUN apt-get -y update && \
 	software-properties-common curl git \
 	make cmake ca-certificates g++ rhash \
 	gcc pkg-config libudev-dev time \
-	clang libssl-dev
+	libssl-dev
+# libssl-dev won't be needed in rust:stretch
 
-# removed:
-# binutils binutils-dev snapcraft gettext file python build-essential zip dpkg-dev rpm libssl-dev openssl ruby-dev
-
-#install nodejs and yarn
+# install nodejs and yarn
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 	curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
@@ -30,7 +30,6 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 
 RUN mkdir /parity-ethereum
 WORKDIR /parity-ethereum
-
 
 # install rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
@@ -53,6 +52,6 @@ ENV CC=gcc \
 
 # pre-download repositories
 RUN git clone https://github.com/paritytech/parity-ethereum.git . && \
-        git submodule update --init --recursive
+	git submodule update --init --recursive
 
 VOLUME /parity-ethereum/artifacts $CARGO_HOME

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -15,16 +15,11 @@ RUN apt-get -y update && \
 	apt-get install -y --no-install-recommends \
 	software-properties-common curl git \
 	make cmake ca-certificates g++ rhash \
-	gcc pkg-config libudev-dev time
+	gcc pkg-config libudev-dev time \
+	clang libssl-dev
 
 # removed:
 # binutils binutils-dev snapcraft gettext file python build-essential zip dpkg-dev rpm libssl-dev openssl ruby-dev
-
-# install rustup
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# rustup directory
-ENV PATH /root/.cargo/bin:$PATH
 
 #install nodejs and yarn
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
@@ -33,24 +28,30 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 	apt-get -y update && apt-get install -y --no-install-recommends \
 	nodejs yarn
 
+# install rustup
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
+	cargo install \
+	cargo-audit \
+	sccache
+
 RUN mkdir /parity-ethereum
 WORKDIR /parity-ethereum
-
-RUN cargo install cargo-audit sccache
-
-# compiler ENV
-ENV CC gcc
-ENV CXX g++
-ENV CARGO_TARGET x86_64-unknown-linux-gnu
-ENV CARGO_HOME /parity-ethereum/.cargo/
-# cache handler
-ENV RUSTC_WRAPPER sccache
-ENV SCCACHE_DIR $CARGO_HOME/sccache
-# show backtraces
-ENV RUST_BACKTRACE 1
 
 # pre-download repositories
 RUN git clone https://github.com/paritytech/parity-ethereum.git . && \
 	git submodule update --init --recursive
+
+	# rustup directory
+ENV PATH=/root/.cargo/bin:$PATH \
+	# compiler ENV
+	CC=gcc \
+	CXX=g++ \
+	CARGO_TARGET=x86_64-unknown-linux-gnu \
+	CARGO_HOME=/parity-ethereum/.cargo/ \
+	# cache handler
+	RUSTC_WRAPPER=sccache \
+	SCCACHE_DIR=$CARGO_HOME/sccache \
+	# show backtraces
+	RUST_BACKTRACE=1
 
 VOLUME /parity-ethereum/artifacts $CARGO_HOME

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -1,6 +1,14 @@
-FROM rust:stretch
+# triggers image autoupdate with the new Rust release
+FROM rust:slim as notifier
+# temporary support of 16.04 with its Clib
+FROM ubuntu:xenial as builder
 LABEL maintainer="Parity Technologies <devops-team@parity.io>"
-LABEL description="This is for CI build stage for Parity Ethereum linux binary."
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="parity/rust-parity-ethereum-build" \
+      org.label-schema.description="This is for CI build stage for Parity Ethereum linux binary." \
+      org.label-schema.url="https://gitlab.com/paritytech/scripts/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci" \
+      org.label-schema.schema-version="1.0"
+
 
 # install tools and dependencies
 RUN apt-get -y update && \
@@ -11,6 +19,12 @@ RUN apt-get -y update && \
 
 # removed:
 # binutils binutils-dev snapcraft gettext file python build-essential zip dpkg-dev rpm libssl-dev openssl ruby-dev
+
+# install rustup
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+# rustup directory
+ENV PATH /root/.cargo/bin:$PATH
 
 #install nodejs and yarn
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -7,9 +7,9 @@ FROM ubuntu:xenial as builder
 # metadata
 LABEL maintainer="devops-team@parity.io" \
 	vendor="Parity Technologies" \
-    name="parity/rust-parity-ethereum-build" \
-    description="This is for CI build stage for Parity Ethereum linux binary." \
-    vcs-url="https://gitlab.com/paritytech/scripts/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci" \
+	name="parity/rust-parity-ethereum-build" \
+	description="This is for CI build stage for Parity Ethereum linux binary." \
+	vcs-url="https://gitlab.com/paritytech/scripts/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci" \
 	url="https://gitlab.com/paritytech"
 
 # install tools and dependencies


### PR DESCRIPTION
- should autoupdate when `rust:slim` does,
- `ubuntu:xenial` based,
- with `sccache` which will allow to proceed with caching between jobs,
- new `label`s to better understand what happens.

Tested, 
- able to build, 
- able to launch in virgin `ubuntu:xenial`.

offer to use this container before we will transfer to static linker.
