### PR TITLE
Upgrading docker builder

### DIFF
--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -48,8 +48,3 @@ ENV CC=gcc \
 	SCCACHE_DIR=/cargo/sccache \
 # show backtraces
 	RUST_BACKTRACE=1
-
-# pre-download repositories
-# RUN git clone https://github.com/paritytech/parity-ethereum.git . && \
-# RUN git clone https://gitlab.parity.io/parity/parity-ethereum.git/ . && \
-# 	git submodule update --init --recursive

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 	apt-get -y update && apt-get install -y --no-install-recommends \
 	nodejs yarn
 
-WORKDIR /parity-ethereum/
+WORKDIR /builds/parity/parity-ethereum/
 
 # install rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 	apt-get -y update && apt-get install -y --no-install-recommends \
 	nodejs yarn
 
-WORKDIR /builds/parity/parity-ethereum/
+WORKDIR /parity-ethereum/
 
 # install rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -51,5 +51,5 @@ ENV CC=gcc \
 
 # pre-download repositories
 # RUN git clone https://github.com/paritytech/parity-ethereum.git . && \
-RUN git clone https://gitlab.parity.io/parity/parity-ethereum.git/ . && \
-	git submodule update --init --recursive
+# RUN git clone https://gitlab.parity.io/parity/parity-ethereum.git/ . && \
+# 	git submodule update --init --recursive

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -50,5 +50,6 @@ ENV CC=gcc \
 	RUST_BACKTRACE=1
 
 # pre-download repositories
-RUN git clone https://github.com/paritytech/parity-ethereum.git . && \
+# RUN git clone https://github.com/paritytech/parity-ethereum.git . && \
+RUN git clone https://gitlab.parity.io/parity/parity-ethereum.git/ . && \
 	git submodule update --init --recursive


### PR DESCRIPTION
no need to pre-download repositories, gitlab docker runner can cache them.