### PR TITLE
Dockerfile for docs

### DIFF
--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -32,14 +32,10 @@ RUN apt-get -y update; \
     url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"; \
     wget "$url"; \
     chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --default-toolchain nightly; \
+    ./rustup-init -y --no-modify-path --default-toolchain stable; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup --version; \
-    cargo --version; \
-    rustc --version; \
 	rustup install nightly beta; \
-	rustup default stable; \
 	cargo install cargo-audit sccache; \
 # apt clean up
     apt-get remove -y --auto-remove \

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -1,6 +1,6 @@
 # triggers image autoupdate with the new Rust release
 # https://github.com/rust-lang-nursery/docker-rust-nightly/blob/master/nightly-slim/Dockerfile
-FROM rustlang/rust:nightly-slim
+FROM rustlang/rust:nightly-slim as notifier
 
 # temporary support of 16.04 with its Clib
 FROM ubuntu:xenial as builder
@@ -16,9 +16,38 @@ LABEL maintainer="devops-team@parity.io" \
 WORKDIR /builds/parity/parity-ethereum/
 
 # rustup directory
-ENV PATH=/root/.cargo/bin:$PATH \
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+# install tools and dependencies
+RUN apt-get -y update; \
+	apt-get install -y --no-install-recommends \
+		software-properties-common curl git \
+		make cmake ca-certificates g++ rhash \
+		gcc pkg-config libudev-dev time \
+		libssl-dev libc6-dev wget; \
+# libssl-dev won't be needed in rust:stretch
+# install rustup
+    url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"; \
+    wget "$url"; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain nightly; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+	rustup install nightly beta; \
+	rustup default stable; \
+	cargo install cargo-audit sccache; \
+# apt clean up
+    apt-get remove -y --auto-remove \
+        wget; \
+	rm -rf /var/lib/apt/lists/*
+
 # compiler ENV
-	CC=gcc \
+RUN CC=gcc \
 	CXX=g++ \
 	CARGO_TARGET=x86_64-unknown-linux-gnu \
 # cache handler
@@ -27,20 +56,3 @@ ENV PATH=/root/.cargo/bin:$PATH \
 	SCCACHE_DIR=/ci-cache/parity-ethereum/sccache \
 # show backtraces
 	RUST_BACKTRACE=1
-
-# install tools and dependencies
-RUN apt-get -y update; \
-	apt-get install -y --no-install-recommends \
-		software-properties-common curl git \
-		make cmake ca-certificates g++ rhash \
-		gcc pkg-config libudev-dev time \
-		libssl-dev; \
-# libssl-dev won't be needed in rust:stretch
-# apt clean up
-	apt-get autoremove -y; \
-	apt-get clean; \
-	rm -rf /var/lib/apt/lists/*; \
-# install rustup
-	curl https://sh.rustup.rs -sSf | sh -s -- -y; \
-	cargo install cargo-audit sccache; \
-	rustup install nightly beta

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -1,5 +1,6 @@
 # triggers image autoupdate with the new Rust release
-FROM rust:slim as notifier
+# https://github.com/rust-lang-nursery/docker-rust-nightly/blob/master/nightly-slim/Dockerfile
+FROM rustlang/rust:nightly-slim
 
 # temporary support of 16.04 with its Clib
 FROM ubuntu:xenial as builder
@@ -8,43 +9,38 @@ FROM ubuntu:xenial as builder
 LABEL maintainer="devops-team@parity.io" \
 	vendor="Parity Technologies" \
 	name="parity/rust-parity-ethereum-build" \
-	description="This is for CI build stage for Parity Ethereum linux binary." \
-	vcs-url="https://gitlab.com/paritytech/scripts/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci" \
-	url="https://gitlab.com/paritytech"
-
-# install tools and dependencies
-RUN apt-get -y update && \
-	apt-get install -y --no-install-recommends \
-	software-properties-common curl git \
-	make cmake ca-certificates g++ rhash \
-	gcc pkg-config libudev-dev time \
-	libssl-dev
-# libssl-dev won't be needed in rust:stretch
-
-# install nodejs and yarn
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-	curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-	apt-get -y update && apt-get install -y --no-install-recommends \
-	nodejs yarn
+	description="Image for CI build stage for Parity Ethereum linux binary." \
+	url="https://gitlab.com/paritytech/scripts" \
+	vcs-url="scripts/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci"
 
 WORKDIR /builds/parity/parity-ethereum/
 
-# install rustup
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
 # rustup directory
-ENV PATH=/root/.cargo/bin:$PATH
-
-RUN cargo install cargo-audit sccache
-
+ENV PATH=/root/.cargo/bin:$PATH \
 # compiler ENV
-ENV CC=gcc \
+	CC=gcc \
 	CXX=g++ \
 	CARGO_TARGET=x86_64-unknown-linux-gnu \
-	CARGO_HOME=/cargo \
 # cache handler
 	RUSTC_WRAPPER=sccache \
-	SCCACHE_DIR=/cargo/sccache \
+	CARGO_HOME=/ci-cache/parity-ethereum/cargo \
+	SCCACHE_DIR=/ci-cache/parity-ethereum/sccache \
 # show backtraces
 	RUST_BACKTRACE=1
+
+# install tools and dependencies
+RUN apt-get -y update; \
+	apt-get install -y --no-install-recommends \
+		software-properties-common curl git \
+		make cmake ca-certificates g++ rhash \
+		gcc pkg-config libudev-dev time \
+		libssl-dev; \
+# libssl-dev won't be needed in rust:stretch
+# apt clean up
+	apt-get autoremove -y; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/lists/*; \
+# install rustup
+	curl https://sh.rustup.rs -sSf | sh -s -- -y; \
+	cargo install cargo-audit sccache; \
+	rustup install nightly beta

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get -y update; \
 	rm -rf /var/lib/apt/lists/*
 
 # compiler ENV
-RUN CC=gcc \
+ENV CC=gcc \
 	CXX=g++ \
 	CARGO_TARGET=x86_64-unknown-linux-gnu \
 # cache handler

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
@@ -10,11 +10,15 @@ LABEL maintainer="devops-team@parity.io" \
 
 WORKDIR /builds/parity/parity-ethereum/
 
+# install tools and dependencies
+RUN apt-get -y update; \
+    apt-get install -y --no-install-recommends \
+        curl ca-certificates; \
 # install nodejs and yarn
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -; \
+	curl -sL https://deb.nodesource.com/setup_10.x | bash -; \
 	curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
-	apt-get -y update && apt-get install -y --no-install-recommends \
+	apt-get install -y --no-install-recommends \
 		nodejs yarn; \
 	# apt clean up
 	apt-get autoremove -y; \

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
@@ -13,11 +13,12 @@ WORKDIR /builds/parity/parity-ethereum/
 # install tools and dependencies
 RUN apt-get -y update; \
     apt-get install -y --no-install-recommends \
-        curl ca-certificates; \
+		curl ca-certificates; \
 # install nodejs and yarn
 	curl -sL https://deb.nodesource.com/setup_10.x | bash -; \
 	curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
+	apt-get -y update; \
 	apt-get install -y --no-install-recommends \
 		nodejs yarn; \
 	# apt clean up

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /builds/parity/parity-ethereum/
 # install tools and dependencies
 RUN apt-get -y update; \
     apt-get install -y --no-install-recommends \
-		curl ca-certificates; \
+		curl ca-certificates git; \
 # install nodejs and yarn
 	curl -sL https://deb.nodesource.com/setup_10.x | bash -; \
 	curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
@@ -11,7 +11,8 @@ LABEL maintainer="devops-team@parity.io" \
 WORKDIR /builds/parity/parity-ethereum/
 
 # install tools and dependencies
-RUN apt-get -y update; \
+RUN set -eux; \
+	apt-get -y update; \
     apt-get install -y --no-install-recommends \
 		curl ca-certificates git; \
 # install nodejs and yarn

--- a/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:xenial as builder
+
+# metadata
+LABEL maintainer="devops-team@parity.io" \
+	vendor="Parity Technologies" \
+	name="parity/rust-parity-ethereum-docs" \
+	description="Image for CI docs stage for Parity Ethereum." \
+	url="https://gitlab.com/paritytech/scripts/" \
+	vcs-url="scripts/docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs"
+
+WORKDIR /builds/parity/parity-ethereum/
+
+# install nodejs and yarn
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -; \
+	curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -; \
+	echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list; \
+	apt-get -y update && apt-get install -y --no-install-recommends \
+		nodejs yarn; \
+	# apt clean up
+	apt-get autoremove -y; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/lists/*

--- a/docker-files-for-Gitlab-CI-rust/substrate-linux-ci/Dockerfile
+++ b/docker-files-for-Gitlab-CI-rust/substrate-linux-ci/Dockerfile
@@ -12,7 +12,8 @@ LABEL maintainer="devops-team@parity.io" \
 WORKDIR /builds/parity/substrate/
 
 # install tools and dependencies
-RUN apt-get -y update; \
+RUN set -eux; \
+	apt-get -y update; \
 	apt-get install -y --no-install-recommends \
 		software-properties-common curl git \
 		make cmake g++ clang rhash \


### PR DESCRIPTION
Parity-ethereum build image:
- new notifier image (official nightly)
- corrected descriptions (is it ok I mention private repo here?)
- beta and nightly Rust added to reintroduce beta and nightly tests
- new cache location to support shared runners
- removed docks dependencies

Parity-ethereum docs image:
- appears

All images will fail during run if errors occurred.