### PR TITLE
Add support for `polkadot-*` names scripts from substrate-up

### DIFF
--- a/get-substrate.sh
+++ b/get-substrate.sh
@@ -79,5 +79,6 @@ fi
 f=`mktemp -d`
 git clone https://github.com/paritytech/substrate-up $f
 cp -a $f/substrate-* ~/.cargo/bin
+cp -a $f/polkadot-* ~/.cargo/bin
 
 echo "Run source ~/.cargo/env now to update environment"


### PR DESCRIPTION
@xlc we need this in order to install the new script