### PR TITLE
Change commands for rustup if it is installed.

### DIFF
--- a/get-substrate.sh
+++ b/get-substrate.sh
@@ -56,6 +56,7 @@ if ! which rustup >/dev/null 2>&1; then
 else
 	rustup toolchain install stable nightly
 	rustup target add wasm32-unknown-unknown --toolchain nightly
+	cargo install --git https://github.com/alexcrichton/wasm-gc
 fi
 
 function install_substrate {

--- a/get-substrate.sh
+++ b/get-substrate.sh
@@ -54,7 +54,8 @@ if ! which rustup >/dev/null 2>&1; then
 	source ~/.cargo/env
 	rustup default stable
 else
-	rustup update
+	rustup toolchain install stable nightly
+	rustup target add wasm32-unknown-unknown --toolchain nightly
 fi
 
 function install_substrate {


### PR DESCRIPTION
In my case I had rustup installed, but for some reason I had no active toolchains (despite using Rust previously).

I think `rustup toolchain install stable nightly` may install or update stable and nightly as needed, or leave unchanged if both are installed and up-to-date, e.g.:
```bash
➜  substrate-package git:(master) ✗ rustup toolchain install stable nightly
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'

  stable-x86_64-unknown-linux-gnu unchanged - rustc 1.34.1 (fc50f328b 2019-04-24)

info: syncing channel updates for 'nightly-x86_64-unknown-linux-gnu'

  nightly-x86_64-unknown-linux-gnu unchanged - rustc 1.36.0-nightly (272000c94 2019-04-28)

info: checking for self-updates
➜  substrate-package git:(master) ✗ 
```
Then add `wasm32-unknown-unknown` as a target to the nightly toolchain and install wasm-gc (as it's still used and needed):
```
	rustup target add wasm32-unknown-unknown --toolchain nightly
	cargo install --git https://github.com/alexcrichton/wasm-gc
```