### PR TITLE
CI simplification I

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,8 +18,6 @@ variables:
   # DOCKER_HOST: tcp://docker:2375
   DOCKER_HOST: tcp://localhost:2375
   DOCKER_DRIVER: overlay2
-  CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
-
 
 
 
@@ -43,18 +41,14 @@ variables:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
     - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
     - docker info
+  variables:
+    CONTAINER_DATE_TAG: "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
   script:
+    - echo $CONTAINER_DATE_TAG
     - cd $DOCKERFILE_DIR
-    - pwd
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
     - export CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
-    - echo $CONTAINER_DATE_TAG
-    - echo "docker build --no-cache
-        --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
-        --build-arg BUILD_DATE="$(date +%Y%m%d)"
-        --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-        --tag $CONTAINER_IMAGE:$CONTAINER_TAG ."
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
@@ -152,7 +146,7 @@ rust-builder:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-builder"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 
 substrate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,7 +144,7 @@ rust-builder:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/rust-builder"
 
 
 substrate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,7 +49,8 @@ variables:
     - pwd
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-    - echo '${DATE}'
+    - echo $DATE
+    - echo $CONTAINER_DATE_TAG
     - echo "docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
         --build-arg BUILD_DATE='${DATE}'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,7 @@ variables:
     - pwd
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
+    - export CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
     - echo $CONTAINER_DATE_TAG
     - echo "docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ variables:
   # DOCKER_HOST: tcp://docker:2375
   DOCKER_HOST: tcp://localhost:2375
   DOCKER_DRIVER: overlay2
+  CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
 
 
 
@@ -46,14 +47,11 @@ variables:
     - cd $DOCKERFILE_DIR
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-    - |
-      if [ "${CONTAINER_DATE_TAG}" ]
-      then
-        docker build --no-cache --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-        docker push $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-      else
-        docker build --no-cache --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-      fi
+    - docker build --no-cache \
+        --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}" \
+        --build-arg BUILD_DATE="$(date +%Y%m%d)" \
+        --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG \
+        --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
     - docker push $CONTAINER_IMAGE:$CONTAINER_TAG
   after_script:
     - docker logout
@@ -61,38 +59,38 @@ variables:
     name: parity-build
 
 
-# Deprecated, use: parity/rust-parity-ethereum-build:xenial
-build:rust:nightly:
+# Deprecated, used only for substrate 1.0
+rust:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/rust
+    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
     CONTAINER_TAG:   nightly
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/rustup
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
 
-build:rust-parity-ethereum-build:xenial:
+rust-parity-ethereum-build:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/rust-parity-ethereum-build
+    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
     CONTAINER_TAG:   xenial
-    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/cross/android
+    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-parity-ethereum-build"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
 
-build:rust-parity-ethereum-android-build:stretch:
+rust-parity-ethereum-android-build:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/rust-parity-ethereum-android-build
+    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
     CONTAINER_TAG:   stretch
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/cross/android
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-parity-ethereum-android-build"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
 
-build:rust-parity-ethereum-build:i386:
+rust-parity-ethereum-build:i386:
   <<: *docker_build
   variables:
     CONTAINER_IMAGE: parity/rust-parity-ethereum-build
@@ -102,7 +100,7 @@ build:rust-parity-ethereum-build:i386:
     variables:
       - $DOCKERIMAGE == "parity/rust-parity-ethereum-build"
 
-build:rust-parity-ethereum-build:arm64:
+rust-parity-ethereum-build:arm64:
   <<: *docker_build
   variables:
     CONTAINER_IMAGE: parity/rust-parity-ethereum-build
@@ -112,7 +110,7 @@ build:rust-parity-ethereum-build:arm64:
     variables:
       - $DOCKERIMAGE == "parity/rust-parity-ethereum-build"
 
-build:parity/rust-parity-ethereum-build:armhf:
+parity/rust-parity-ethereum-build:armhf:
   <<: *docker_build
   variables:
     CONTAINER_IMAGE: parity/rust-parity-ethereum-build
@@ -128,79 +126,78 @@ build:parity/rust-parity-ethereum-build:armhf:
 
 
 
-build:rust-parity-ethereum-docs:xenial:
+rust-parity-ethereum-docs:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/rust-parity-ethereum-docs
+    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
     CONTAINER_TAG:   xenial
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-parity-ethereum-docs"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
 
-build:rust-substrate-build:stretch:
+rust-builder:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/rust-substrate-build
-    CONTAINER_TAG:   stretch
-    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/substrate-linux-ci
+    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
+    CONTAINER_TAG:   latest
+    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/{$CI_JOB_NAME}
   only:
     variables:
-      - $DOCKERIMAGE == "parity/substrate-linux-ci"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
 
-build:substrate:nightly:
+
+substrate:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/substrate
+    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
     CONTAINER_TAG:   nightly
-    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/substrate
+    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/{$CI_JOB_NAME}
   only:
     variables:
-      - $DOCKERIMAGE == "parity/substrate"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
 
 
 
 
 
-build:awscli:latest:
+awscli:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:     parity/awscli
+    CONTAINER_IMAGE:     parity/{$CI_JOB_NAME}
     CONTAINER_TAG:       latest
-    DOCKERFILE_DIR:      awscli
+    DOCKERFILE_DIR:      $CI_JOB_NAME
     CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
   only:
     variables:
-      - $DOCKERIMAGE == "parity/awscli"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
 
 
-build:tools:latest:
+tools:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:     parity/tools
+    CONTAINER_IMAGE:     parity/{$CI_JOB_NAME}
     CONTAINER_TAG:       latest
-    DOCKERFILE_DIR:      tools
-    CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
+    DOCKERFILE_DIR:      $CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/tools"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
 
 
 # special case as version tags are introduced
-build:kubetools:
+kubetools:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:         parity/kubetools
+    CONTAINER_IMAGE:         parity/{$CI_JOB_NAME}
     CONTAINER_TAG:           latest
-    DOCKERFILE_DIR:          kubetools
+    DOCKERFILE_DIR:          $CI_JOB_NAME
     # https://github.com/kubernetes/kubernetes/releases
     KUBE_VERSION:            "1.13.4"
     # https://github.com/kubernetes/helm/releases
     HELM_VERSION:            "2.13.1"
-    CONTAINER_DATE_TAG:      "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
   only:
     variables:
-      - $DOCKERIMAGE == "parity/kubetools"
+      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
   script:
     - cd $DOCKERFILE_DIR
     - docker build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ rust:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/rustup
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/rust"
 
 rust-parity-ethereum-build:
   <<: *docker_build
@@ -80,7 +80,7 @@ rust-parity-ethereum-build:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/rust-parity-ethereum-build"
 
 rust-parity-ethereum-android-build:
   <<: *docker_build
@@ -90,7 +90,7 @@ rust-parity-ethereum-android-build:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/cross/android
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/rust-parity-ethereum-android-build"
 
 rust-parity-ethereum-build:i386:
   <<: *docker_build
@@ -136,7 +136,7 @@ rust-parity-ethereum-docs:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/rust-parity-ethereum-docs"
 
 rust-builder:
   <<: *docker_build
@@ -146,7 +146,7 @@ rust-builder:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == parity/${CI_JOB_NAME}
+      - $DOCKERIMAGE == "parity/rust-builder"
 
 
 substrate:
@@ -157,7 +157,7 @@ substrate:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/substrate"
 
 
 
@@ -172,7 +172,7 @@ awscli:
     CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/awscli"
 
 
 tools:
@@ -183,7 +183,7 @@ tools:
     DOCKERFILE_DIR:      $CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/tools"
 
 
 # special case as version tags are introduced
@@ -199,7 +199,7 @@ kubetools:
     HELM_VERSION:            "2.13.1"
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/kubetools"
   script:
     - cd $DOCKERFILE_DIR
     - docker build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,7 +146,7 @@ rust-builder:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/${CI_JOB_NAME}"
+      - $DOCKERIMAGE == parity/${CI_JOB_NAME}
 
 
 substrate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,7 +143,7 @@ rust-builder:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == $CONTAINER_IMAGE
+      - $DOCKERIMAGE == "parity/rust-builder"
 
 
 substrate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,15 +48,15 @@ variables:
     - pwd
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-    - echo "docker build --no-cache \
-        --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}" \
-        --build-arg BUILD_DATE="$(date +%Y%m%d)" \
-        --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG \
+    - echo "docker build --no-cache
+        --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
+        --build-arg BUILD_DATE="$(date +%Y%m%d)"
+        --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag $CONTAINER_IMAGE:$CONTAINER_TAG ."
-    - docker build --no-cache \
-        --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}" \
-        --build-arg BUILD_DATE="$(date +%Y%m%d)" \
-        --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG \
+    - docker build --no-cache
+        --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
+        --build-arg BUILD_DATE="$(date +%Y%m%d)"
+        --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
     - docker push $CONTAINER_IMAGE:$CONTAINER_TAG
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,35 +60,35 @@ variables:
 
 
 # Deprecated, used only for substrate 1.0 and polkadot 0.4
-rust:
+parity/rust:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/$CI_JOB_NAME
+    CONTAINER_IMAGE: $CI_JOB_NAME
     CONTAINER_TAG:   nightly
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/rustup
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust"
+      - $DOCKERIMAGE == $CI_JOB_NAME
 
-rust-parity-ethereum-build:
+parity/rust-parity-ethereum-build:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/$CI_JOB_NAME
+    CONTAINER_IMAGE: $CI_JOB_NAME
     CONTAINER_TAG:   xenial
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-parity-ethereum-build"
+      - $DOCKERIMAGE == $CI_JOB_NAME
 
-rust-parity-ethereum-android-build:
+parity/rust-parity-ethereum-android-build:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/$CI_JOB_NAME
+    CONTAINER_IMAGE: $CI_JOB_NAME
     CONTAINER_TAG:   stretch
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/cross/android
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-parity-ethereum-android-build"
+      - $DOCKERIMAGE == $CI_JOB_NAME
 
 rust-parity-ethereum-build:i386:
   <<: *docker_build
@@ -110,7 +110,7 @@ rust-parity-ethereum-build:arm64:
     variables:
       - $DOCKERIMAGE == "parity/rust-parity-ethereum-build"
 
-parity/rust-parity-ethereum-build:armhf:
+rust-parity-ethereum-build:armhf:
   <<: *docker_build
   variables:
     CONTAINER_IMAGE: parity/rust-parity-ethereum-build
@@ -120,15 +120,15 @@ parity/rust-parity-ethereum-build:armhf:
     variables:
       - $DOCKERIMAGE == "parity/rust-parity-ethereum-build"
 
-rust-parity-ethereum-docs:
+parity/rust-parity-ethereum-docs:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/$CI_JOB_NAME
+    CONTAINER_IMAGE: $CI_JOB_NAME
     CONTAINER_TAG:   xenial
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-parity-ethereum-docs"
+      - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity/rust-builder:
   <<: *docker_build
@@ -141,40 +141,40 @@ parity/rust-builder:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 
-awscli:
+parity/awscli:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:     parity/$CI_JOB_NAME
+    CONTAINER_IMAGE:     $CI_JOB_NAME
     CONTAINER_TAG:       latest
     DOCKERFILE_DIR:      $CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/awscli"
+      - $DOCKERIMAGE == $CI_JOB_NAME
 
-tools:
+parity/tools:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:     parity/$CI_JOB_NAME
+    CONTAINER_IMAGE:     $CI_JOB_NAME
     CONTAINER_TAG:       latest
     DOCKERFILE_DIR:      $CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/tools"
+      - $DOCKERIMAGE == $CI_JOB_NAME
 
 # special case as version tags are introduced
-kubetools:
+parity/kubetools:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:         parity/$CI_JOB_NAME
+    CONTAINER_IMAGE:         $CI_JOB_NAME
     CONTAINER_TAG:           latest
-    DOCKERFILE_DIR:          $CI_JOB_NAME
+    DOCKERFILE_DIR:          kubetools
     # https://github.com/kubernetes/kubernetes/releases
     KUBE_VERSION:            "1.13.4"
     # https://github.com/kubernetes/helm/releases
     HELM_VERSION:            "2.13.1"
   only:
     variables:
-      - $DOCKERIMAGE == "parity/kubetools"
+      - $DOCKERIMAGE == $CI_JOB_NAME
   script:
     - cd $DOCKERFILE_DIR
     - docker build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,10 +16,9 @@ stages:
 variables:
   # CONTAINER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH
   # DOCKER_HOST: tcp://docker:2375
-  DOCKER_HOST:                     tcp://localhost:2375
-  DOCKER_DRIVER:                   overlay2
-  DATE:                            "$(git show -s --format=%ct $CI_COMMIT_SHA)"
-  CONTAINER_DATE_TAG:              "${CI_COMMIT_SHORT_SHA}-$DATE"
+  DOCKER_HOST: tcp://localhost:2375
+  DOCKER_DRIVER: overlay2
+  CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
 
 
 
@@ -49,16 +48,15 @@ variables:
     - pwd
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-    - echo $DATE
     - echo $CONTAINER_DATE_TAG
     - echo "docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
-        --build-arg BUILD_DATE='${DATE}'
+        --build-arg BUILD_DATE="$(date +%Y%m%d)"
         --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag $CONTAINER_IMAGE:$CONTAINER_TAG ."
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
-        --build-arg BUILD_DATE="${DATE}"
+        --build-arg BUILD_DATE="$(date +%Y%m%d)"
         --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
     - docker push $CONTAINER_IMAGE:$CONTAINER_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,7 @@ variables:
     - kubernetes-parity-build
 
 
-.build: &docker_build
+.build:                            &docker_build
   stage: build
   <<:                              *kubernetes-build
   image:                           docker:stable
@@ -63,32 +63,32 @@ variables:
 rust:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE: parity/$CI_JOB_NAME
     CONTAINER_TAG:   nightly
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/rustup
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 rust-parity-ethereum-build:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE: parity/$CI_JOB_NAME
     CONTAINER_TAG:   xenial
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/parity-eth-linux-ci
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 rust-parity-ethereum-android-build:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE: parity/$CI_JOB_NAME
     CONTAINER_TAG:   stretch
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/cross/android
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 rust-parity-ethereum-build:i386:
   <<: *docker_build
@@ -129,33 +129,33 @@ parity/rust-parity-ethereum-build:armhf:
 rust-parity-ethereum-docs:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE: parity/$CI_JOB_NAME
     CONTAINER_TAG:   xenial
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/parity-eth-linux-docs
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 rust-builder:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE: parity/$CI_JOB_NAME
     CONTAINER_TAG:   latest
-    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/{$CI_JOB_NAME}
+    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 
 substrate:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE: parity/$CI_JOB_NAME
     CONTAINER_TAG:   nightly
-    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/{$CI_JOB_NAME}
+    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 
 
@@ -164,31 +164,31 @@ substrate:
 awscli:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:     parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE:     parity/$CI_JOB_NAME
     CONTAINER_TAG:       latest
     DOCKERFILE_DIR:      $CI_JOB_NAME
     CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 
 tools:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:     parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE:     parity/$CI_JOB_NAME
     CONTAINER_TAG:       latest
     DOCKERFILE_DIR:      $CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
 
 
 # special case as version tags are introduced
 kubetools:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE:         parity/{$CI_JOB_NAME}
+    CONTAINER_IMAGE:         parity/$CI_JOB_NAME
     CONTAINER_TAG:           latest
     DOCKERFILE_DIR:          $CI_JOB_NAME
     # https://github.com/kubernetes/kubernetes/releases
@@ -197,7 +197,7 @@ kubetools:
     HELM_VERSION:            "2.13.1"
   only:
     variables:
-      - $DOCKERIMAGE == "parity/{$CI_JOB_NAME}"
+      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
   script:
     - cd $DOCKERFILE_DIR
     - docker build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,8 +45,14 @@ variables:
     - docker info
   script:
     - cd $DOCKERFILE_DIR
+    - pwd
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
+    - echo "docker build --no-cache \
+        --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}" \
+        --build-arg BUILD_DATE="$(date +%Y%m%d)" \
+        --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG \
+        --tag $CONTAINER_IMAGE:$CONTAINER_TAG ."
     - docker build --no-cache \
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}" \
         --build-arg BUILD_DATE="$(date +%Y%m%d)" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,8 +18,8 @@ variables:
   # DOCKER_HOST: tcp://docker:2375
   DOCKER_HOST:                     tcp://localhost:2375
   DOCKER_DRIVER:                   overlay2
-  DATE:                            $(date +%Y%m%d)
-  CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$DATE"
+  DATE:                            "$(date +%Y%m%d)"
+  CONTAINER_DATE_TAG:              "${CI_COMMIT_SHORT_SHA}-$DATE"
 
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,7 @@ variables:
     - pwd
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
+    - echo '${DATE}'
     - echo "docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
         --build-arg BUILD_DATE='${DATE}'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,7 @@ variables:
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
         --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
+    - docker push $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
     - docker push $CONTAINER_IMAGE:$CONTAINER_TAG
   after_script:
     - docker logout
@@ -129,15 +130,15 @@ rust-parity-ethereum-docs:
     variables:
       - $DOCKERIMAGE == "parity/rust-parity-ethereum-docs"
 
-rust-builder:
+parity/rust-builder:
   <<: *docker_build
   variables:
-    CONTAINER_IMAGE: parity/$CI_JOB_NAME
+    CONTAINER_IMAGE: $CI_JOB_NAME
     CONTAINER_TAG:   latest
-    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
+    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/rust-builder
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-builder"
+      - $DOCKERIMAGE == $CI_JOB_NAME
 
 
 awscli:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ variables:
     - cd $DOCKERFILE_DIR
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-    - export CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
+    # - export CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,7 +58,7 @@ variables:
     name: parity-build
 
 
-# Deprecated, used only for substrate 1.0
+# Deprecated, used only for substrate 1.0 and polkadot 0.4
 rust:
   <<: *docker_build
   variables:
@@ -119,12 +119,6 @@ parity/rust-parity-ethereum-build:armhf:
     variables:
       - $DOCKERIMAGE == "parity/rust-parity-ethereum-build"
 
-
-
-
-
-
-
 rust-parity-ethereum-docs:
   <<: *docker_build
   variables:
@@ -146,20 +140,6 @@ rust-builder:
       - $DOCKERIMAGE == "parity/rust-builder"
 
 
-substrate:
-  <<: *docker_build
-  variables:
-    CONTAINER_IMAGE: parity/$CI_JOB_NAME
-    CONTAINER_TAG:   nightly
-    DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
-  only:
-    variables:
-      - $DOCKERIMAGE == "parity/substrate"
-
-
-
-
-
 awscli:
   <<: *docker_build
   variables:
@@ -170,7 +150,6 @@ awscli:
     variables:
       - $DOCKERIMAGE == "parity/awscli"
 
-
 tools:
   <<: *docker_build
   variables:
@@ -180,7 +159,6 @@ tools:
   only:
     variables:
       - $DOCKERIMAGE == "parity/tools"
-
 
 # special case as version tags are introduced
 kubetools:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -143,7 +143,7 @@ rust-builder:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/rust-builder"
+      - $DOCKERIMAGE == $CONTAINER_IMAGE
 
 
 substrate:
@@ -166,7 +166,6 @@ awscli:
     CONTAINER_IMAGE:     parity/$CI_JOB_NAME
     CONTAINER_TAG:       latest
     DOCKERFILE_DIR:      $CI_JOB_NAME
-    CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
   only:
     variables:
       - $DOCKERIMAGE == "parity/awscli"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ variables:
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
     - echo "docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
-        --build-arg BUILD_DATE='$(date +%Y%m%d)'
+        --build-arg BUILD_DATE='${DATE}'
         --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag $CONTAINER_IMAGE:$CONTAINER_TAG ."
     - docker build --no-cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -146,7 +146,7 @@ rust-builder:
     DOCKERFILE_DIR:  docker-files-for-Gitlab-CI-rust/$CI_JOB_NAME
   only:
     variables:
-      - $DOCKERIMAGE == "parity/$CI_JOB_NAME"
+      - $DOCKERIMAGE == "parity/${CI_JOB_NAME}"
 
 
 substrate:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,9 +16,10 @@ stages:
 variables:
   # CONTAINER_IMAGE: registry.gitlab.com/$CI_PROJECT_PATH
   # DOCKER_HOST: tcp://docker:2375
-  DOCKER_HOST: tcp://localhost:2375
-  DOCKER_DRIVER: overlay2
-  CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
+  DOCKER_HOST:                     tcp://localhost:2375
+  DOCKER_DRIVER:                   overlay2
+  DATE:                            $(date +%Y%m%d)
+  CONTAINER_DATE_TAG:  "${CI_COMMIT_SHORT_SHA}-$DATE"
 
 
 
@@ -50,12 +51,12 @@ variables:
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
     - echo "docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
-        --build-arg BUILD_DATE="$(date +%Y%m%d)"
+        --build-arg BUILD_DATE='$(date +%Y%m%d)'
         --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag $CONTAINER_IMAGE:$CONTAINER_TAG ."
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
-        --build-arg BUILD_DATE="$(date +%Y%m%d)"
+        --build-arg BUILD_DATE="${DATE}"
         --tag $CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
     - docker push $CONTAINER_IMAGE:$CONTAINER_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ variables:
   # DOCKER_HOST: tcp://docker:2375
   DOCKER_HOST:                     tcp://localhost:2375
   DOCKER_DRIVER:                   overlay2
-  DATE:                            "$(date +%Y%m%d)"
+  DATE:                            "$(git show -s --format=%ct $CI_COMMIT_SHA)"
   CONTAINER_DATE_TAG:              "${CI_COMMIT_SHORT_SHA}-$DATE"
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,14 +41,11 @@ variables:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
     - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
     - docker info
-  variables:
-    CONTAINER_DATE_TAG: "${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
   script:
-    - echo $CONTAINER_DATE_TAG
     - cd $DOCKERFILE_DIR
     # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
     # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-    # - export CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
+    - export CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHORT_SHA}"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"


### PR DESCRIPTION
# important:
- fix wrong dir for `rust-parity-ethereum-build`
- new name and dir for ex-`parity-substrate-builder`, now `rust-builder`, the universal image for substrate-based stuff
- fix for `$CONTAINER_DATE_TAG`
# features:
The idea is to bring the order to the repository.
`$CI_JOB_NAME` should match an image name (without a tag), Dockerfile dir and a variable for launching the schedule.
This is not the final change, it will require further renaming if the images and their dirs.
Renaming will be according the naming rules, and the documentation will follow.
Also, each Dockerfile will have the metadata and it also will be described in the doc.
As we decided about the design, all the docker images should have tags `short-sha` or `short-sha+date` and be pulled everywhere by the `latest` default tag. It will be completed later.
When it will be done, we'll be able to remove many lines from `.gitlab-ci.yml`
- introduced variables for the metadata
- `$CONTAINER_DATE_TAG` defined in a template