### PR TITLE
Fix syntax for /health check

### DIFF
--- a/polkasync/deployment.yaml
+++ b/polkasync/deployment.yaml
@@ -221,7 +221,7 @@ data:
             return self.send(status = 502)
     
     
-          if system_health["peers"] < 2 and system_health["shouldHavePeers"] == true:
+          if system_health["peers"] < 2 and system_health["shouldHavePeers"] == True:
             return self.send(status = 500)
     
           return self.send("OK %s\n" % system_health["peers"])


### PR DESCRIPTION
Fix issue:

```
Exception happened during processing of request from ('127.0.0.1', 53474)
Traceback (most recent call last):
  File "/usr/lib/python3.6/socketserver.py", line 320, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/lib/python3.6/socketserver.py", line 351, in process_request
    self.finish_request(request, client_address)
  File "/usr/lib/python3.6/socketserver.py", line 364, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.6/socketserver.py", line 724, in __init__
    self.handle()
  File "/usr/lib/python3.6/http/server.py", line 418, in handle
    self.handle_one_request()
  File "/usr/lib/python3.6/http/server.py", line 406, in handle_one_request
    method()
  File "dotexporter.py", line 73, in do_GET
    if system_health["peers"] < 2 and system_health["shouldHavePeers"] == true:
NameError: name 'true' is not defined
```