### PR TITLE
add to sccache features redis

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ variables:
   <<:                              *docker_build
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-    - docker login -u $CI_DEPLOY_USER -p $CI_DEPLOY_PASSWORD $CI_REGISTRY
+    - docker login -u $CI_DEPLOY_USER -p $CI_DEPLOY_PASSWORD $CI_REGISTRY/pub/ci
     - docker info
   script:
     - cd dockerfiles/$DOCKERFILE_DIR
@@ -72,8 +72,8 @@ variables:
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHA}"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
-        --tag registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-        --tag registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG .
+        --tag $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
+        --tag $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG .
     - docker push $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
     - docker push $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,25 +63,21 @@ variables:
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    # - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.parity.io
-    # - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - docker info
   script:
+    # $CI_REGISTRY_IMAGE == registry.parity.io/parity/infrastructure/scripts/
+    # $CI_REGISTRY == registry.parity.io/
     - cd dockerfiles/$DOCKERFILE_DIR
-    # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
-    # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
-    - export CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
+    # - docker pull $CI_REGISTRY_IMAGE/$CONTAINER_IMAGE:$CONTAINER_TAG || true
+    - CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
+    # - docker build --cache-from $CI_REGISTRY_IMAGE/$CONTAINER_IMAGE:$CONTAINER_TAG
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHA}"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
         --tag $CI_REGISTRY_IMAGE/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-        --tag $CI_REGISTRY/parity/infrastructure/scripts/$CONTAINER_IMAGE:$CONTAINER_TAG
-        --tag registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
-        --tag registry.parity.io/$CONTAINER_IMAGE:$CONTAINER_TAG .
+        --tag $CI_REGISTRY_IMAGE/$CONTAINER_IMAGE:$CONTAINER_TAG .
     - docker push $CI_REGISTRY_IMAGE/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-    - docker push $CI_REGISTRY/parity/infrastructure/scripts/$CONTAINER_IMAGE:$CONTAINER_TAG
-    - docker push registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
-    - docker push registry.parity.io/$CONTAINER_IMAGE:$CONTAINER_TAG 
+    - docker push $CI_REGISTRY_IMAGE/$CONTAINER_IMAGE:$CONTAINER_TAG
 
 
 # TODO: check/change substrate 1.0, polkadot 0.4, zcash, parity-pharma, parity-bitcoin, light and remove this image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,6 @@ variables:
   <<:                              *docker_build
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-    # - docker login registry.parity.io
     - docker login -u $CI_DEPLOY_USER -p $CI_DEPLOY_PASSWORD $CI_REGISTRY
     - docker info
   script:
@@ -75,8 +74,8 @@ variables:
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
         --tag registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
         --tag registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG .
-    - docker push registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-    - docker push registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
+    - docker push $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
+    - docker push $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
 
 
 # TODO: check/change substrate 1.0, polkadot 0.4, zcash, parity-pharma, parity-bitcoin, light and remove this image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,7 +90,7 @@ rust:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-linux:
-  <<:                              &docker_build_to_own_reg
+  <<:                              *docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -100,7 +100,7 @@ parity-ci-linux:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-android:
-  <<:                              &docker_build_to_own_reg
+  <<:                              *docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 stretch
@@ -110,7 +110,7 @@ parity-ci-android:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-i386:
-  <<:                              &docker_build_to_own_reg
+  <<:                              *docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -120,7 +120,7 @@ parity-ci-i386:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-arm64:
-  <<:                              &docker_build_to_own_reg
+  <<:                              *docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -130,7 +130,7 @@ parity-ci-arm64:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-armhf:
-  <<:                              &docker_build_to_own_reg
+  <<:                              *docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -140,7 +140,7 @@ parity-ci-armhf:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-docs:
-  <<:                              &docker_build_to_own_reg
+  <<:                              *docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -161,7 +161,7 @@ rust-builder:
 
 
 awscli:
-  <<:                              &docker_build_to_own_reg
+  <<:                              *docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,8 @@ variables:
   <<:                              *docker_build
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-    - docker login registry.parity.io
+    # - docker login registry.parity.io
+    - docker login -u $CI_DEPLOY_USER -p $CI_DEPLOY_PASSWORD $CI_REGISTRY
     - docker info
   script:
     - cd dockerfiles/$DOCKERFILE_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,8 +62,8 @@ variables:
   <<:                              *docker_build
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-    # - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY/pub/ci/
-    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.parity.io
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    # - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.parity.io
     # - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - docker info
   script:
@@ -74,10 +74,14 @@ variables:
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHA}"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
-        --tag $CI_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-        --tag $CI_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_TAG .
-    - docker push $CI_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-    - docker push $CI_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_TAG
+        --tag $CI_REGISTRY_IMAGE/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
+        --tag $CI_REGISTRY/parity/infrastructure/scripts/$CONTAINER_IMAGE:$CONTAINER_TAG
+        --tag registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
+        --tag registry.parity.io/$CONTAINER_IMAGE:$CONTAINER_TAG .
+    - docker push $CI_REGISTRY_IMAGE/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
+    - docker push $CI_REGISTRY/parity/infrastructure/scripts/$CONTAINER_IMAGE:$CONTAINER_TAG
+    - docker push registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
+    - docker push registry.parity.io/$CONTAINER_IMAGE:$CONTAINER_TAG 
 
 
 # TODO: check/change substrate 1.0, polkadot 0.4, zcash, parity-pharma, parity-bitcoin, light and remove this image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ variables:
   <<:                              *docker_build
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-    - docker login -u gitlab+deploy-token-8 -p $CI_DEPLOY_PASSWORD $CI_REGISTRY/pub/ci
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
     - docker info
   script:
     - cd dockerfiles/$DOCKERFILE_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ variables:
   <<:                              *docker_build
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY/pub/ci/
     - docker info
   script:
     - cd dockerfiles/$DOCKERFILE_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -74,10 +74,10 @@ variables:
     - docker build --no-cache
         --build-arg VCS_REF="${CI_COMMIT_SHA}"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
-        --tag $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-        --tag $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG .
-    - docker push $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
-    - docker push $CI_REGISTRY/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
+        --tag $CI_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
+        --tag $CI_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_TAG .
+    - docker push $CI_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
+    - docker push $CI_REGISTRY/$CONTAINER_IMAGE:$CONTAINER_TAG
 
 
 # TODO: check/change substrate 1.0, polkadot 0.4, zcash, parity-pharma, parity-bitcoin, light and remove this image

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,25 @@ variables:
   environment:
     name: parity-build
 
+.build_to_own_reg:                 &docker_build_to_own_reg
+  <<:                              *docker_build
+  before_script:
+    - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
+    - docker login registry.parity.io
+    - docker info
+  script:
+    - cd dockerfiles/$DOCKERFILE_DIR
+    # - docker pull $CONTAINER_IMAGE:$CONTAINER_TAG || true
+    # - docker build --cache-from $CONTAINER_IMAGE:$CONTAINER_TAG --tag $CONTAINER_IMAGE:$CI_BUILD_REF --tag $CONTAINER_IMAGE:$CONTAINER_TAG .
+    - export CONTAINER_DATE_TAG="${CI_COMMIT_SHORT_SHA}-$(date +%Y%m%d)"
+    - docker build --no-cache
+        --build-arg VCS_REF="${CI_COMMIT_SHA}"
+        --build-arg BUILD_DATE="$(date +%Y%m%d)"
+        --tag registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
+        --tag registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG .
+    - docker push registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_DATE_TAG
+    - docker push registry.parity.io/pub/ci/$CONTAINER_IMAGE:$CONTAINER_TAG
+
 
 # TODO: check/change substrate 1.0, polkadot 0.4, zcash, parity-pharma, parity-bitcoin, light and remove this image
 rust:
@@ -71,7 +90,7 @@ rust:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-linux:
-  <<: *docker_build
+  <<:                              &docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -81,7 +100,7 @@ parity-ci-linux:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-android:
-  <<: *docker_build
+  <<:                              &docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 stretch
@@ -91,7 +110,7 @@ parity-ci-android:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-i386:
-  <<: *docker_build
+  <<:                              &docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -101,7 +120,7 @@ parity-ci-i386:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-arm64:
-  <<: *docker_build
+  <<:                              &docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -111,7 +130,7 @@ parity-ci-arm64:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-armhf:
-  <<: *docker_build
+  <<:                              &docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -121,7 +140,7 @@ parity-ci-armhf:
       - $DOCKERIMAGE == $CI_JOB_NAME
 
 parity-ci-docs:
-  <<: *docker_build
+  <<:                              &docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest
@@ -142,7 +161,7 @@ rust-builder:
 
 
 awscli:
-  <<: *docker_build
+  <<:                              &docker_build_to_own_reg
   variables:
     CONTAINER_IMAGE:               $CI_JOB_NAME
     CONTAINER_TAG:                 latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,6 @@ variables:
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker info
   script:
     # $CI_REGISTRY_IMAGE == registry.parity.io/parity/infrastructure/scripts/
     # $CI_REGISTRY == registry.parity.io/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ variables:
   <<:                              *docker_build
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-    - docker login -u $CI_DEPLOY_USER -p $CI_DEPLOY_PASSWORD $CI_REGISTRY/pub/ci
+    - docker login -u gitlab+deploy-token-8 -p $CI_DEPLOY_PASSWORD $CI_REGISTRY/pub/ci
     - docker info
   script:
     - cd dockerfiles/$DOCKERFILE_DIR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,9 @@ variables:
   <<:                              *docker_build
   before_script:
     - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY/pub/ci/
+    # - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY/pub/ci/
+    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN registry.parity.io
+    # - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - docker info
   script:
     - cd dockerfiles/$DOCKERFILE_DIR

--- a/dockerfiles/awscli/Dockerfile
+++ b/dockerfiles/awscli/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="parity/awscli" \
+	io.parity.image.title="registry.parity.io/parity/infrastructure/scripts/awscli" \
 	io.parity.image.description="awscli" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/awscli/Dockerfile" \

--- a/dockerfiles/parity-ci-android/Dockerfile
+++ b/dockerfiles/parity-ci-android/Dockerfile
@@ -7,7 +7,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="parity/parity-ci-android" \
+	io.parity.image.title="registry.parity.io/pub/ci/parity-ci-android" \
 	io.parity.image.description="cmake rhash libudev-dev time xsltproc gperf; libudev.patch; \
 android ndk r16b; cargo target arm-linux-androideabi, cargo target armv7-linux-androideabi" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/parity-ci-android/Dockerfile
+++ b/dockerfiles/parity-ci-android/Dockerfile
@@ -57,7 +57,7 @@ RUN set -eux; \
 # autotools-dev automake autoconf libtool docbook-xsl
 	rustup target add arm-linux-androideabi; \
 	rustup target add armv7-linux-androideabi; \
-	cargo install sccache; \
+	cargo install sccache --features redis; \
 # Android NDK and toolchain
 	cd /usr/local; \
 	wget -q https://dl.google.com/android/repository/android-ndk-r16b-linux-x86_64.zip; \

--- a/dockerfiles/parity-ci-android/Dockerfile
+++ b/dockerfiles/parity-ci-android/Dockerfile
@@ -7,7 +7,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="registry.parity.io/pub/ci/parity-ci-android" \
+	io.parity.image.title="registry.parity.io/parity/infrastructure/scripts/parity-ci-android" \
 	io.parity.image.description="cmake rhash libudev-dev time xsltproc gperf; libudev.patch; \
 android ndk r16b; cargo target arm-linux-androideabi, cargo target armv7-linux-androideabi" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/parity-ci-android/README.md
+++ b/dockerfiles/parity-ci-android/README.md
@@ -4,7 +4,7 @@ Uses [sccache](https://github.com/mozilla/sccache).
 # Usage
 ```linux-armv7-android:
       stage: build
-      image: parity/parity-ci-android:stretch
+      image: registry.parity.io/parity/infrastructure/scripts/parity-ci-android:stretch
       script:
         - cargo build ...
 ```

--- a/dockerfiles/parity-ci-arm64/Dockerfile
+++ b/dockerfiles/parity-ci-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM parity/parity-ci-linux:latest as builder
+FROM registry.parity.io/pub/ci/parity-ci-linux:latest as builder
 
 # metadata
 ARG VCS_REF
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="parity/parity-ci-arm64" \
+	io.parity.image.title="registry.parity.io/pub/ci/parity-ci-arm64" \
 	io.parity.image.description="g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libudev-dev \
 libudev-dev:arm64; rustup target aarch64-unknown-linux-gnu" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/parity-ci-arm64/Dockerfile
+++ b/dockerfiles/parity-ci-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.parity.io/pub/ci/parity-ci-linux:latest as builder
+FROM registry.parity.io/parity/infrastructure/scripts/parity-ci-linux:latest as builder
 
 # metadata
 ARG VCS_REF
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="registry.parity.io/pub/ci/parity-ci-arm64" \
+	io.parity.image.title="registry.parity.io/parity/infrastructure/scripts/parity-ci-arm64" \
 	io.parity.image.description="g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libudev-dev \
 libudev-dev:arm64; rustup target aarch64-unknown-linux-gnu" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/parity-ci-arm64/README.md
+++ b/dockerfiles/parity-ci-arm64/README.md
@@ -5,7 +5,7 @@ Uses [sccache](https://github.com/mozilla/sccache).
 ```
     build-linux-arm64:
       stage: build
-      image: parity/parity-ci-arm64:latest
+      image: registry.parity.io/parity/infrastructure/scripts/parity-ci-arm64:latest
       script:
         - cargo build build --target aarch64-unknown-linux-gnu $CARGO_OPTIONS
 ```

--- a/dockerfiles/parity-ci-armhf/Dockerfile
+++ b/dockerfiles/parity-ci-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.parity.io/pub/ci/parity-ci-linux:latest as builder
+FROM registry.parity.io/parity/infrastructure/scripts/parity-ci-linux:latest as builder
 
 # metadata
 ARG VCS_REF
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="registry.parity.io/pub/ci/parity-ci-armhf" \
+	io.parity.image.title="registry.parity.io/parity/infrastructure/scripts/parity-ci-armhf" \
 	io.parity.image.description="g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf libudev-dev \
 libudev-dev:armhf; cargo target armv7-unknown-linux-gnueabihf" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/parity-ci-armhf/Dockerfile
+++ b/dockerfiles/parity-ci-armhf/Dockerfile
@@ -1,4 +1,4 @@
-FROM parity/parity-ci-linux:latest as builder
+FROM registry.parity.io/pub/ci/parity-ci-linux:latest as builder
 
 # metadata
 ARG VCS_REF
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="parity/parity-ci-armhf" \
+	io.parity.image.title="registry.parity.io/pub/ci/parity-ci-armhf" \
 	io.parity.image.description="g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf libudev-dev \
 libudev-dev:armhf; cargo target armv7-unknown-linux-gnueabihf" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/parity-ci-armhf/README.md
+++ b/dockerfiles/parity-ci-armhf/README.md
@@ -5,7 +5,7 @@ Uses [sccache](https://github.com/mozilla/sccache).
 ```
     build-linux-armhf:
       stage: build
-      image: parity/parity-ci-armhf:latest
+      image: registry.parity.io/parity/infrastructure/scripts/parity-ci-armhf:latest
       script:
         - cargo build --target armv7-unknown-linux-gnueabihf $CARGO_OPTIONS
 ```

--- a/dockerfiles/parity-ci-docs/Dockerfile
+++ b/dockerfiles/parity-ci-docs/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="parity/parity-ci-docs" \
+	io.parity.image.title="registry.parity.io/parity/infrastructure/scripts/parity-ci-docs" \
 	io.parity.image.description="curl ca-certificates git; nodejs yarn" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/parity-ci-docs/Dockerfile" \

--- a/dockerfiles/parity-ci-i386/Dockerfile
+++ b/dockerfiles/parity-ci-i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM parity/parity-ci-linux:latest as builder
+FROM registry.parity.io/pub/ci/parity-ci-linux:latest as builder
 
 # metadata
 ARG VCS_REF
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="parity/parity-ci-i386" \
+	io.parity.image.title="registry.parity.io/pub/ci/parity-ci-i386" \
 	io.parity.image.description="gcc-multilib g++-multilib libudev-dev libudev-dev:i386; \
 cargo target i686-unknown-linux-gnu" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/parity-ci-i386/Dockerfile
+++ b/dockerfiles/parity-ci-i386/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.parity.io/pub/ci/parity-ci-linux:latest as builder
+FROM registry.parity.io/parity/infrastructure/scripts/parity-ci-linux:latest as builder
 
 # metadata
 ARG VCS_REF
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="registry.parity.io/pub/ci/parity-ci-i386" \
+	io.parity.image.title="registry.parity.io/parity/infrastructure/scripts/parity-ci-i386" \
 	io.parity.image.description="gcc-multilib g++-multilib libudev-dev libudev-dev:i386; \
 cargo target i686-unknown-linux-gnu" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/parity-ci-i386/README.md
+++ b/dockerfiles/parity-ci-i386/README.md
@@ -5,7 +5,7 @@ Uses [sccache](https://github.com/mozilla/sccache).
 ```
     build-linux-i386:
       stage: build
-      image: parity/parity-ci-i386:latest
+      image: registry.parity.io/parity/infrastructure/scripts/parity-ci-i386:latest
       script:
         - cargo build --target i686-unknown-linux-gnu $CARGO_OPTIONS
 ```

--- a/dockerfiles/parity-ci-linux/Dockerfile
+++ b/dockerfiles/parity-ci-linux/Dockerfile
@@ -6,7 +6,7 @@ ARG BUILD_DATE
 
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="parity/parity-ci-linux" \
+	io.parity.image.title="registry.parity.io/parity/infrastructure/scripts/parity-ci-linux" \
 	io.parity.image.description="curl git make cmake ca-certificates g++ rhash gcc \
 pkg-config libudev-dev time libssl-dev libc6-dev \
 rust stable/beta/nightly, cargo-audit, sccache" \

--- a/dockerfiles/parity-ci-linux/Dockerfile
+++ b/dockerfiles/parity-ci-linux/Dockerfile
@@ -40,7 +40,8 @@ RUN set -eux; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
 	rustup install nightly beta; \
-	cargo install cargo-audit sccache; \
+	cargo install cargo-audit; \
+	cargo install sccache --features redis; \
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \

--- a/dockerfiles/parity-ci-linux/README.md
+++ b/dockerfiles/parity-ci-linux/README.md
@@ -13,7 +13,7 @@ Usage:
 ```
 build-linux:
     stage: build
-    image: parity/parity-ci-linux:latest
+    image: registry.parity.io/parity/infrastructure/scripts/parity-ci-linux:latest
     script:
       - cargo build ...
 ```


### PR DESCRIPTION
All the images which are used in parity-ethereum build process are now being published to our Gitilab docker container registry.
These images now are making use of `sccache` with Redis to avoid the data race condition when pruning old cache pieces.
Metadata was also edited to show the current addresses of the images.
