### PR TITLE
shrink service images

### DIFF
--- a/dockerfiles/parity-ci-android/Dockerfile
+++ b/dockerfiles/parity-ci-android/Dockerfile
@@ -47,17 +47,18 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		cmake rhash libudev-dev \
 		time xsltproc gperf; \
+	rustup target add arm-linux-androideabi; \
+	rustup target add armv7-linux-androideabi; \
+	cargo install sccache --features redis; \
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \
 	rm -rf /var/lib/apt/lists/*; \
-# removed:
-# wget curl ca-certificates g++ git unzip
-# sudo file build-essential bison flex lib32stdc++6 lib32z1 python
-# autotools-dev automake autoconf libtool docbook-xsl
-	rustup target add arm-linux-androideabi; \
-	rustup target add armv7-linux-androideabi; \
-	cargo install sccache --features redis; \
+# cargo clean up
+# removes compilation artifacts cargo install creates (>250M)
+	rm -rf $CARGO_HOME/registry; \
+# removes toolchain's html docs and autocompletions (>300M for each toolchain)
+	rm -rf /usr/local/rustup/toolchains/*/share; \
 # Android NDK and toolchain
 	cd /usr/local; \
 	wget -q https://dl.google.com/android/repository/android-ndk-r16b-linux-x86_64.zip; \
@@ -93,4 +94,4 @@ ENV	RUSTC_WRAPPER=sccache \
 # show backtraces
 	RUST_BACKTRACE=1
 
-WORKDIR /builds/parity/parity-ethereum/
+WORKDIR /builds

--- a/dockerfiles/parity-ci-arm64/Dockerfile
+++ b/dockerfiles/parity-ci-arm64/Dockerfile
@@ -36,12 +36,17 @@ RUN set -eux; \
 	apt-get install -y \
 		g++-aarch64-linux-gnu gcc-aarch64-linux-gnu \
 		libudev-dev libudev-dev:arm64; \
+# install aarch64 toolchain
+	rustup target add aarch64-unknown-linux-gnu; \
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \
 	rm -rf /var/lib/apt/lists/*; \
-# install aarch64 toolchain
-	rustup target add aarch64-unknown-linux-gnu
+# cargo clean up
+# removes compilation artifacts cargo install creates (>250M)
+	rm -rf $CARGO_HOME/registry; \
+# removes toolchain's html docs and autocompletions (>300M for each toolchain)
+	rm -rf /usr/local/rustup/toolchains/*/share;
 
 # set cross-compiler ENV
 ADD config /.cargo/config

--- a/dockerfiles/parity-ci-armhf/Dockerfile
+++ b/dockerfiles/parity-ci-armhf/Dockerfile
@@ -36,12 +36,17 @@ RUN set -eux; \
 	apt-get install -y \
 		g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf \
 		libudev-dev libudev-dev:armhf; \
+# install armv7 toolchain
+	rustup target add armv7-unknown-linux-gnueabihf; \
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \
 	rm -rf /var/lib/apt/lists/*; \
-# install armv7 toolchain
-	rustup target add armv7-unknown-linux-gnueabihf
+# cargo clean up
+# removes compilation artifacts cargo install creates (>250M)
+	rm -rf $CARGO_HOME/registry; \
+# removes toolchain's html docs and autocompletions (>300M for each toolchain)
+	rm -rf /usr/local/rustup/toolchains/*/share;
 
 # set cross-compiler ENV
 ADD config /.cargo/config

--- a/dockerfiles/parity-ci-i386/Dockerfile
+++ b/dockerfiles/parity-ci-i386/Dockerfile
@@ -24,12 +24,17 @@ RUN set -eux; \
 	apt install -y \
 		gcc-multilib g++-multilib \
 		libudev-dev libudev-dev:i386; \
+# install i686 toolchain
+	rustup target add i686-unknown-linux-gnu;\
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \
 	rm -rf /var/lib/apt/lists/*; \
-# install i686 toolchain
-	rustup target add i686-unknown-linux-gnu
+# cargo clean up
+# removes compilation artifacts cargo install creates (>250M)
+	rm -rf $CARGO_HOME/registry; \
+# removes toolchain's html docs and autocompletions (>300M for each toolchain)
+	rm -rf /usr/local/rustup/toolchains/*/share;
 
 # set cross-compiler ENV
 ENV CC=gcc \

--- a/dockerfiles/parity-ci-linux/Dockerfile
+++ b/dockerfiles/parity-ci-linux/Dockerfile
@@ -42,6 +42,11 @@ RUN set -eux; \
 	rustup install nightly beta; \
 	cargo install cargo-audit; \
 	cargo install sccache --features redis; \
+# cargo clean up
+# removes compilation artifacts cargo install creates (>250M)
+	rm -rf $CARGO_HOME/registry; \
+# removes toolchain's html docs and autocompletions (>300M for each toolchain)
+	rm -rf /usr/local/rustup/toolchains/*/share; \
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \

--- a/dockerfiles/rust-builder/Dockerfile
+++ b/dockerfiles/rust-builder/Dockerfile
@@ -49,6 +49,11 @@ RUN set -eux; \
 # versions
 	rustup show; \
 	cargo --version; \
+# cargo clean up
+# removes compilation artifacts cargo install creates (>250M)
+	rm -rf $CARGO_HOME/registry; \
+# removes toolchain's html docs and autocompletions (>300M for each toolchain)
+	rm -rf /usr/local/rustup/toolchains/*/share; \
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \


### PR DESCRIPTION
Painlessly shrinks every `$CARGO_HOME` for >250M and every installed toolchain by >300M