### PR TITLE
Add bash to the tools Docker image

### DIFF
--- a/dockerfiles/tools/Dockerfile
+++ b/dockerfiles/tools/Dockerfile
@@ -15,6 +15,6 @@ dockerfiles/tools/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
-RUN apk add --no-cache curl git jq rsync make gettext gnupg
+RUN apk add --no-cache curl git jq rsync make gettext gnupg bash
 
 CMD /bin/sh


### PR DESCRIPTION
At least one script I've written requires bash-specific features. It would be useful to be able to make use of this docker image since it also contains lots of tools I regularly make use of