### PR TITLE
Add deprecation message to get-parity.io

### DIFF
--- a/get-parity.sh
+++ b/get-parity.sh
@@ -134,6 +134,14 @@ cleanup() {
 
 ## MAIN ##
 
+cat << EOF
+[!] Parity Ethereum is now Open Ethereum! As a result, this script will no longer
+be maintained, and there are no guarantees about availability of the binaries.
+The new home for Open Ethereum is https://github.com/OpenEthereum/open-ethereum/
+Any further development of the project can be tracked from this page.
+For more information, see: https://www.parity.io/parity-ethereum-openethereum-dao/
+EOF
+
 ## curl installed? 
 which curl &> /dev/null 
 if [[ $? -ne 0 ]] ; then

--- a/get-parity.sh
+++ b/get-parity.sh
@@ -135,12 +135,16 @@ cleanup() {
 ## MAIN ##
 
 cat << EOF
-[!] Parity Ethereum is now Open Ethereum! As a result, this script will no longer
-be maintained, and there are no guarantees about availability of the binaries.
-The new home for Open Ethereum is https://github.com/OpenEthereum/open-ethereum/
-Any further development of the project can be tracked from this page.
-For more information, see: https://www.parity.io/parity-ethereum-openethereum-dao/
++====================================================================================+
+| [!] Parity Ethereum is now Open Ethereum! As a result, this script will no longer  |
+| be maintained, and there are no guarantees about availability of the binaries.     |
+| The new home for Open Ethereum is https://github.com/OpenEthereum/open-ethereum/   |
+| Any further development of the project can be tracked from this page.              |
+| For more information, see: https://www.parity.io/parity-ethereum-openethereum-dao/ |
+=====================================================================================+
+
 EOF
+sleep 2
 
 ## curl installed? 
 which curl &> /dev/null 


### PR DESCRIPTION
Alerts users that parity-ethereum is now open-ethereum and provides a link to the new location