### PR TITLE
Update ink CI image

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -20,14 +20,11 @@ WORKDIR /builds
 
 # install specific Rust nightly toolchain
 # see on https://rust-lang.github.io/rustup-components-history/
-RUN	rustup install nightly-2020-02-01; \
-	rustup component add --toolchain nightly-2020-02-01 clippy; \
-	rustup target add --toolchain nightly-2020-02-01 wasm32-unknown-unknown; \
-	rustup default nightly-2020-02-17; \
+RUN	rustup default nightly-2020-03-12; \
 # install wasm32 target for this toolchain
-    rustup target add wasm32-unknown-unknown; \
+	rustup target add --toolchain nightly-2020-03-12 wasm32-unknown-unknown; \
 # install cargo tools
-    rustup component add rustfmt clippy; \
+	rustup component add rustfmt clippy; \
 	cargo install grcov; \
 	cargo install --git https://github.com/paritytech/cargo-contract; \
 # versions


### PR DESCRIPTION
clippy bug is fixed, workaround is not needed anymore.