### PR TITLE
substrate ci images fixes

### DIFF
--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -39,7 +39,7 @@ RUN set -eux; \
 		libssl-dev clang lld libclang-dev make cmake \
 		git pkg-config curl time rhash ca-certificates; \
 # set a link to clang
-	ln -sf /usr/bin/clang /usr/bin/cc; \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
 # install rustup
   	chmod +x rustup-init; \
   	./rustup-init -y --no-modify-path --default-toolchain stable; \

--- a/dockerfiles/rust-builder/Dockerfile
+++ b/dockerfiles/rust-builder/Dockerfile
@@ -39,10 +39,10 @@ RUN set -eux; \
 # install geckodriver
 	curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest \
 		| grep 'browser_download_url.*linux64.tar.gz"' \
-		| cut -d : -f 2,3 | tr -d \" | xargs -n 1 curl -sSL \
-		| tar -xzC /usr/bin; \
+		| cut -d : -f 2,3 | sort -V | tail -n1 \
+		| xargs -n 1 curl -sSL | tar -xzC /usr/local/bin ; \
 # set a link to clang
-	ln -sf /usr/bin/clang /usr/bin/cc; \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
 # install rustup
 	chmod +x rustup-init; \
 	./rustup-init -y --no-modify-path --default-toolchain stable; \
@@ -55,7 +55,7 @@ RUN set -eux; \
 		cargo-audit cargo-web wasm-pack; \
 	cargo install sccache --features redis; \
 # TODO: install published version once 0.2.60 gets released
-	cargo install --git https://github.com/rustwasm/wasm-bindgen wasm-bindgen-cli; \
+	cargo install wasm-bindgen-cli; \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown; \
 	rustup target add wasm32-unknown-unknown --toolchain nightly; \

--- a/dockerfiles/substrate-ci-linux/Dockerfile
+++ b/dockerfiles/substrate-ci-linux/Dockerfile
@@ -26,12 +26,12 @@ RUN set -eux; \
 # install geckodriver
 	curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest \
 		| grep 'browser_download_url.*linux64.tar.gz"' \
-		| cut -d : -f 2,3 | tr -d \" | xargs -n 1 curl -sSL \
-		| tar -xzC /usr/bin; \
+		| cut -d : -f 2,3 | sort -V | tail -n1 \
+		| xargs -n 1 curl -sSL | tar -xzC /usr/local/bin ; \
 # install cargo tools
 	cargo install cargo-audit cargo-web wasm-pack; \
 # TODO: install published version once 0.2.60 gets released
-	cargo install --git https://github.com/rustwasm/wasm-bindgen wasm-bindgen-cli; \
+	cargo install wasm-bindgen-cli; \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown; \
 	rustup target add wasm32-unknown-unknown --toolchain nightly; \


### PR DESCRIPTION
fix `wasm-bindgen-cli` installation trouble; 
add grumbles from #161: 
better curling, 
clang linking