### PR TITLE
add cargo-deny to substrate images

### DIFF
--- a/dockerfiles/rust-builder/Dockerfile
+++ b/dockerfiles/rust-builder/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.title="parity/rust-builder" \
 	io.parity.image.description="libssl-dev, clang, libclang-dev, lld, cmake, make, git, pkg-config, \
 curl, time, rhash, ca-certificates, firefox-esr, geckodriver; \
-rust stable, rust nightly, cargo-audit, sccache, wasm-gc, wasm-bindgen" \
+rust stable, rust nightly, cargo-audit, sccache, wasm-gc, wasm-bindgen cargo-deny" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/rust-builder/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -52,7 +52,7 @@ RUN set -eux; \
 	rustup install nightly; \
 # install cargo tools
 	cargo install \
-		cargo-audit cargo-web wasm-pack; \
+		cargo-audit cargo-web wasm-pack cargo-deny; \
 	cargo install sccache --features redis; \
 # TODO: install published version once 0.2.60 gets released
 	cargo install wasm-bindgen-cli; \

--- a/dockerfiles/rust-builder/README.md
+++ b/dockerfiles/rust-builder/README.md
@@ -36,6 +36,7 @@ Used to build and test `Substrate`-based projects.
 - `sccache`
 - `wasm-pack`
 - `wasm-bindgen`
+- `cargo-deny`
 - `wasm32-unknown-unknown` toolchain
 
 ## Usage

--- a/dockerfiles/substrate-ci-linux/Dockerfile
+++ b/dockerfiles/substrate-ci-linux/Dockerfile
@@ -8,7 +8,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="registry.parity.io/parity/infrastructure/scripts/substrate-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux; firefox-esr, geckodriver; \
-wasm-gc, wasm-bindgen" \
+wasm-gc, wasm-bindgen cargo-deny" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/rust-builder/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -29,7 +29,7 @@ RUN set -eux; \
 		| cut -d : -f 2,3 | sort -V | tail -n1 \
 		| xargs -n 1 curl -sSL | tar -xzC /usr/local/bin ; \
 # install cargo tools
-	cargo install cargo-audit cargo-web wasm-pack; \
+	cargo install cargo-audit cargo-web wasm-pack cargo-deny; \
 # TODO: install published version once 0.2.60 gets released
 	cargo install wasm-bindgen-cli; \
 # install wasm toolchain

--- a/dockerfiles/substrate-ci-linux/README.md
+++ b/dockerfiles/substrate-ci-linux/README.md
@@ -39,6 +39,7 @@ Used to build and test Substrate-based projects.
 - `sccache`
 - `wasm-pack`
 - `wasm-bindgen`
+- `cargo-deny`
 - `wasm32-unknown-unknown` toolchain
 
 [Click here](https://registry.parity.io/parity/infrastructure/scripts/substrate-ci-linux) for the registry.


### PR DESCRIPTION
Adds `cargo-deny` to substrate CI images.
(probably later it would make sense to add it to `base-ci-linux`)