### PR TITLE
ink!: update Rust version to nightly-2020-04-06

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -20,9 +20,9 @@ WORKDIR /builds
 
 # install specific Rust nightly toolchain
 # see on https://rust-lang.github.io/rustup-components-history/
-RUN	rustup default nightly-2020-03-12; \
+RUN	rustup default nightly-2020-04-06; \
 # install wasm32 target for this toolchain
-	rustup target add --toolchain nightly-2020-03-12 wasm32-unknown-unknown; \
+	rustup target add --toolchain nightly-2020-04-06 wasm32-unknown-unknown; \
 # install cargo tools
 	rustup component add rustfmt clippy; \
 	cargo install grcov; \


### PR DESCRIPTION
The `2020-04-07` nightly release contains all the required tools:
https://rust-lang.github.io/rustup-components-history/