### PR TITLE
fix ink! dockerfile

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /builds
 # see on https://rust-lang.github.io/rustup-components-history/
 RUN	rustup default nightly-2020-05-03; \
 # install wasm32 target for this toolchain
-	rustup target add --toolchain nightly-2020-04-07 wasm32-unknown-unknown; \
+	rustup target add --toolchain nightly-2020-05-03 wasm32-unknown-unknown; \
 # install cargo tools
 	rustup component add rustfmt clippy; \
 	cargo install grcov; \

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /builds
 RUN	set -eux; \
 	rustup default nightly-2020-05-03; \
 # install wasm32 target for this toolchain
-	rustup target add --toolchain nightly-2020-05-03 wasm32-unknown-unknown; \
+	rustup target add wasm32-unknown-unknown; \
 # install cargo tools
 	rustup component add rustfmt clippy; \
 	cargo install grcov; \

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -20,7 +20,8 @@ WORKDIR /builds
 
 # install specific Rust nightly toolchain
 # see on https://rust-lang.github.io/rustup-components-history/
-RUN	rustup default nightly-2020-05-03; \
+RUN	set -eux; \
+	rustup default nightly-2020-05-03; \
 # install wasm32 target for this toolchain
 	rustup target add --toolchain nightly-2020-05-03 wasm32-unknown-unknown; \
 # install cargo tools


### PR DESCRIPTION
fixes nightly base to install wasm target
fail on errors, not set vars and trace level of script execution