### PR TITLE
Prep to deprecation in GitLab 13

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,22 +22,16 @@ variables:
 .build:                            &docker_build
   stage:                           build
   image:                           docker:stable
-  only:
-    refs:
-      - schedules
-      - web
-    kubernetes:                    active
+  rules:
+    - if:                          '$DOCKERIMAGE == $CI_JOB_NAME'
+    - changes:                     
+      - dockerfiles/${IMAGE_NAME}'
   tags:
     - kubernetes-parity-build
   services:
     - docker:dind
   environment:
     name:                          parity-build
-  before_script:
-    - test -z "$DOCKERIMAGE" && echo "DOCKERIMAGE must be defined" && exit 1
-  only:
-    variables:
-      - $DOCKERIMAGE == $CI_JOB_NAME
 
 # Push to Dockerhub
 .push_to_docker_hub:               &push_to_docker_hub
@@ -215,9 +209,10 @@ terraform:
 # in order to be scanned, EVERY docker build HAS to have $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
 container_scanning:
   stage:                           test
-  only:
-    variables:
-      - $DOCKERIMAGE
+  rules:
+    # this is similar to only: variables: $x
+    - if:                          '$DOCKERIMAGE'
+      when:                        always
   variables:
     GIT_STRATEGY:                  fetch
     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$DOCKERIMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,6 @@ variables:
   DOCKER_DRIVER:                   overlay2
   IMAGE_NAME:                      $CI_JOB_NAME
   IMAGE_TAG:                       latest
-  DOCKERFILE_DIR:                  $CI_JOB_NAME
   REGISTRY_PATH:                   paritytech
   CI_REGISTRY_PATH:                "registry.parity.io/parity/infrastructure/scripts"
 
@@ -50,7 +49,7 @@ variables:
         --build-arg REGISTRY_PATH=$REGISTRY_PATH
         --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
         --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-        --file $DOCKERFILE_DIR/Dockerfile .
+        --file $IMAGE_NAME/Dockerfile .
     - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
     - docker info
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
@@ -136,7 +135,7 @@ chaostools:
       --build-arg REGISTRY_PATH=$REGISTRY_PATH
       --build-arg KUBE_VERSION="${BUILD_KUBE_VERSION}"
       --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --file $DOCKERFILE_DIR/Dockerfile .
+      --file $IMAGE_NAME/Dockerfile .
     # Push to Dockerhub
     - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
     - docker info
@@ -172,7 +171,7 @@ kubetools:
       --build-arg HELM_VERSION="${BUILD_HELM_VERSION}"
       --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
       --tag $REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION
-      --file $DOCKERFILE_DIR/Dockerfile .
+      --file $IMAGE_NAME/Dockerfile .
     # Push to Dockerhub
     - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
     - docker info
@@ -203,7 +202,7 @@ terraform:
       --build-arg TERRAFORM_VERSION="${TERRAFORM_VERSION}"
       --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
       --tag $REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION
-      --file $DOCKERFILE_DIR/Dockerfile .
+      --file $IMAGE_NAME/Dockerfile .
     # Push to Dockerhub
     - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
     - docker info
@@ -214,7 +213,7 @@ terraform:
 
 # triggers on $DOCKERIMAGE
 # in order to be scanned, EVERY docker build HAS to have $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-container_scanning: # for dockerhub
+container_scanning:
   stage:                           test
   only:
     variables:
@@ -223,7 +222,7 @@ container_scanning: # for dockerhub
     GIT_STRATEGY:                  fetch
     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$DOCKERIMAGE
     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
-    DOCKERFILE_PATH:               "dockerfiles/${DOCKERFILE_DIR}/Dockerfile"
+    DOCKERFILE_PATH:               "dockerfiles/${DOCKERIMAGE}"
     DOCKER_USER:                   $Docker_Hub_User_Parity
     DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,6 @@
 # .gitlab-ci.yml
 # paritytech/scripts
 #
-# triggers the container scanning built-in tool
-include:
-  - template:                      Container-Scanning.gitlab-ci.yml
 
 stages:
   - build
@@ -23,9 +20,11 @@ variables:
   stage:                           build
   image:                           docker:stable
   rules:
+    # same as only: variables: $x
     - if:                          '$DOCKERIMAGE == $CI_JOB_NAME'
-    - changes:                     
-      - dockerfiles/${IMAGE_NAME}'
+    # triggers rebuild when Dockerfile is changed
+    - changes:
+      - 'dockerfiles/${IMAGE_NAME}/Dockerfile'
   tags:
     - kubernetes-parity-build
   services:
@@ -208,18 +207,37 @@ terraform:
 # triggers on $DOCKERIMAGE
 # in order to be scanned, EVERY docker build HAS to have $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
 container_scanning:
+  # Template does not work, had to reimplement its config from
+  # https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml
   stage:                           test
-  rules:
-    # this is similar to only: variables: $x
-    - if:                          '$DOCKERIMAGE'
-      when:                        always
+  image:                           $SECURE_ANALYZERS_PREFIX/klar:$CS_MAJOR_VERSION
   variables:
+    SECURE_ANALYZERS_PREFIX:       "registry.gitlab.com/gitlab-org/security-products/analyzers"
+    CS_MAJOR_VERSION:              2
+    CLAIR_DB_IMAGE_TAG:            "latest"
+    CLAIR_DB_IMAGE:                "$SECURE_ANALYZERS_PREFIX/clair-vulnerabilities-db:$CLAIR_DB_IMAGE_TAG"
     GIT_STRATEGY:                  fetch
     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$DOCKERIMAGE
     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
     DOCKERFILE_PATH:               "dockerfiles/${DOCKERIMAGE}"
     DOCKER_USER:                   $Docker_Hub_User_Parity
     DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
-
+  allow_failure:                   true
+  services:
+    - name:                        $CLAIR_DB_IMAGE
+      alias:                       clair-vulnerabilities-db
+  script:
+    - /analyzer run
+  artifacts:
+    reports:
+      container_scanning:          gl-container-scanning-report.json
+  dependencies: []
+  rules:
+    # same as only: variables: $x
+    - if:                          '$DOCKERIMAGE'
+      when:                        always
+    # triggers rebuild when Dockerfile is changed
+    - changes:
+      - 'dockerfiles/${IMAGE_NAME}/Dockerfile'
 
 # vim: expandtab sts=2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,7 @@ variables:
         --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
         --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
         --file $IMAGE_NAME/Dockerfile .
-    - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
+    - docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
     - docker info
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
@@ -130,7 +130,7 @@ chaostools:
       --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
       --file $IMAGE_NAME/Dockerfile .
     # Push to Dockerhub
-    - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
+    - docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
     - docker info
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
     - docker logout
@@ -166,7 +166,7 @@ kubetools:
       --tag $REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION
       --file $IMAGE_NAME/Dockerfile .
     # Push to Dockerhub
-    - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
+    - docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
     - docker info
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION
@@ -197,7 +197,7 @@ terraform:
       --tag $REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION
       --file $IMAGE_NAME/Dockerfile .
     # Push to Dockerhub
-    - docker login -u "${Docker_Hub_User_Parity}" -p "${Docker_Hub_Pass_Parity}"
+    - docker login -u "${DOCKER_USER}" -p "${DOCKER_PASSWORD}"
     - docker info
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION
@@ -222,8 +222,6 @@ container_scanning:
     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$DOCKERIMAGE
     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
     DOCKERFILE_PATH:               "dockerfiles/${DOCKERIMAGE}"
-    DOCKER_USER:                   $Docker_Hub_User_Parity
-    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
   allow_failure:                   true
   services:
     - name:                        $CLAIR_DB_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,10 +212,12 @@ container_scanning:
   stage:                           test
   image:                           $SECURE_ANALYZERS_PREFIX/klar:$CS_MAJOR_VERSION
   variables:
+    # these variables are from the template
     SECURE_ANALYZERS_PREFIX:       "registry.gitlab.com/gitlab-org/security-products/analyzers"
     CS_MAJOR_VERSION:              2
     CLAIR_DB_IMAGE_TAG:            "latest"
     CLAIR_DB_IMAGE:                "$SECURE_ANALYZERS_PREFIX/clair-vulnerabilities-db:$CLAIR_DB_IMAGE_TAG"
+    # these are our custom variables
     GIT_STRATEGY:                  fetch
     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$DOCKERIMAGE
     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG


### PR DESCRIPTION
Before v13 we have to move from using `only/except` with templates, so trying to do it I stumbled upon a bug that their template [uses](https://gitlab.com/gitlab-org/gitlab/-/blob/68ba7914479b56bb04f5737f6e410772b3f70812/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml#L28) `only`.
Had to workaround their [official](https://docs.gitlab.com/ee/user/application_security/container_scanning/#configuration) suggestion.