### PR TITLE
ink!: Update Rust nightly version

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -34,7 +34,7 @@ RUN	set -eux; \
 #
 # Visit https://rust-lang.github.io/rustup-components-history/ to see which
 # components are available for which nightly build.
-	rustup default nightly-2020-05-30; \
+	rustup default nightly-2020-05-31; \
 	# Install wasm32 target for this toolchain
 	rustup target add wasm32-unknown-unknown; \
 	rustup component add rustfmt clippy miri rust-src; \

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -34,7 +34,7 @@ RUN	set -eux; \
 #
 # Visit https://rust-lang.github.io/rustup-components-history/ to see which
 # components are available for which nightly build.
-	rustup default nightly-2020-05-14; \
+	rustup default nightly-2020-05-30; \
 	# Install wasm32 target for this toolchain
 	rustup target add wasm32-unknown-unknown; \
 	rustup component add rustfmt clippy miri rust-src; \


### PR DESCRIPTION
Updates the Rust nightly version of the ink! dockerfile to `2020-05-30`.