### PR TITLE
Override base image to use fixed sccache before its release

### DIFF
--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -1,16 +1,17 @@
-FROM debian:buster
+FROM debian:buster-slim
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""
 ARG REGISTRY_PATH=paritytech
 
 # metadata
-LABEL io.parity.image.authors="devops-team@parity.io" \
-	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="${REGISTRY_PATH}/base-ci-linux" \
-	io.parity.image.description="Layer 1 image with all dependencies for Rust and WASM compilation. \
-libssl-dev, clang, libclang-dev, lld, cmake, make, git, pkg-config \
+LABEL summary="Layer 1 image with all dependencies for Rust and WASM compilation." \
+	name="${REGISTRY_PATH}/base-ci-linux" \
+	maintainer="devops-team@parity.io" \
+	version="1.0" \
+	description="libssl-dev, clang, libclang-dev, lld, cmake, make, git, pkg-config \
 curl, time, rhash, rust stable, rust nightly, sccache" \
+	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/base-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -34,21 +35,21 @@ ADD "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-in
 
 # install tools and dependencies
 RUN set -eux; \
-	apt -y update; \
-	apt install -y --no-install-recommends \
+	apt-get -y update; \
+	apt-get install -y --no-install-recommends \
 		libssl-dev clang lld libclang-dev make cmake \
 		git pkg-config curl time rhash ca-certificates; \
 # set a link to clang
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
-# install rustup
+# install rustup, use minimum components
   	chmod +x rustup-init; \
-  	./rustup-init -y --no-modify-path --default-toolchain stable; \
+  	./rustup-init -y --no-modify-path --profile minimal --default-toolchain stable; \
   	rm rustup-init; \
   	chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-# install Rust nightly, default is stable
-	rustup install nightly; \
 # install sccache
-	cargo install sccache --features redis; \
+	# FIXME: TEMPORARY OVERRIDE
+	# cargo install sccache --features redis; \
+	cargo install --git https://github.com/mozilla/sccache --features redis; \
 # versions
 	rustup show; \
 	cargo --version; \
@@ -58,8 +59,8 @@ RUN set -eux; \
 # removes toolchain's html docs and autocompletions (>300M for each toolchain)
 	rm -rf /usr/local/rustup/toolchains/*/share; \
 # apt clean up
-	apt autoremove -y; \
-	apt clean; \
+	apt-get autoremove -y; \
+	apt-get clean; \
 	rm -rf /var/lib/apt/lists/*
 # cache handler
 ENV	RUSTC_WRAPPER=sccache \

--- a/dockerfiles/base-ci-linux/README.md
+++ b/dockerfiles/base-ci-linux/README.md
@@ -23,15 +23,11 @@ Used to build and test Substrate-based projects.
 - `rhash`
 - `ca-certificates`
 
-**Rust versions:**
-
-- stable (default)
-- nightly
-
 [Click here](https://hub.docker.com/repository/docker/paritytech/base-ci-linux) for the registry.
 
 **Rust tools & toolchains:**
 
+- stable (default)
 - `sccache`
 
 ## Usage

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -36,6 +36,8 @@ RUN set -eux; \
 # set a link to clang-8
 	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100; \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100; \
+# install nightly Rust
+	rustup install nightly; \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown --toolchain nightly; \
 # install cargo tools

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -36,6 +36,8 @@ RUN set -eux; \
 # set a link to clang-8
 	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100; \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100; \
+# use minimum components
+	rustup set profile minimal; \
 # install nightly Rust
 	rustup install nightly; \
 # install wasm toolchain

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -34,6 +34,8 @@ RUN	set -eux; \
 #
 # Visit https://rust-lang.github.io/rustup-components-history/ to see which
 # components are available for which nightly build.
+# use minimum components
+	rustup set profile minimal; \
 	rustup default nightly-2020-05-31; \
 	# Install wasm32 target for this toolchain
 	rustup target add wasm32-unknown-unknown; \
@@ -45,5 +47,5 @@ RUN	set -eux; \
 	cargo --version; \
 	# Clean up and remove compilation artifacts that a cargo install creates (>250M).
 	# Also removes toolchain's HTML, docs and autocompletions (>300M for each toolchain).
-	rm -rf $CARGO_HOME/registry; \
+	rm -rf "$CARGO_HOME/registry"; \
 	rm -rf /usr/local/rustup/toolchains/*/share;

--- a/dockerfiles/substrate-ci-linux/Dockerfile
+++ b/dockerfiles/substrate-ci-linux/Dockerfile
@@ -22,6 +22,8 @@ RUN set -eux; \
 	apt-get -y update; \
 	apt-get install -y --no-install-recommends \
 		chromium-driver; \
+# use minimum components
+	rustup set profile minimal; \
 # install Rust nightly, default is stable
 	rustup install nightly; \
 # install cargo tools

--- a/dockerfiles/substrate-ci-linux/Dockerfile
+++ b/dockerfiles/substrate-ci-linux/Dockerfile
@@ -29,6 +29,8 @@ RUN set -eux; \
 	rustup target add wasm32-unknown-unknown --toolchain nightly; \
 # install wasm-gc. It's useful for stripping slimming down wasm binaries (polkadot)
 	cargo +nightly install wasm-gc; \
+# FIXME: TEMPORARY OVERRIDE
+	cargo install --git https://github.com/mozilla/sccache; \
 # versions
 	rustup show; \
 	cargo --version; \

--- a/dockerfiles/substrate-ci-linux/Dockerfile
+++ b/dockerfiles/substrate-ci-linux/Dockerfile
@@ -19,9 +19,11 @@ dockerfiles/substrate-ci-linux/README.md" \
 
 # install tools and dependencies
 RUN set -eux; \
-	apt -y update; \
-	apt install -y --no-install-recommends \
+	apt-get -y update; \
+	apt-get install -y --no-install-recommends \
 		chromium-driver; \
+# install Rust nightly, default is stable
+	rustup install nightly; \
 # install cargo tools
 	cargo install cargo-audit cargo-web wasm-pack cargo-deny wasm-bindgen-cli; \
 # install wasm toolchain
@@ -29,14 +31,12 @@ RUN set -eux; \
 	rustup target add wasm32-unknown-unknown --toolchain nightly; \
 # install wasm-gc. It's useful for stripping slimming down wasm binaries (polkadot)
 	cargo +nightly install wasm-gc; \
-# FIXME: TEMPORARY OVERRIDE
-	cargo install --git https://github.com/mozilla/sccache; \
 # versions
 	rustup show; \
 	cargo --version; \
 # apt clean up
-	apt autoremove -y; \
-	apt clean; \
+	apt-get autoremove -y; \
+	apt-get clean; \
 	rm -rf /var/lib/apt/lists/*; \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)


### PR DESCRIPTION
- temporary `sccache` is installed from the master branch, it contains a fix we need


Accidentally did some optimizations:
- moved to `buster-slim` base. Not much thinner, but the attack surface is lower.
- added minimal profile, so rust doesn't take all the default components, we were installing them anyways. This decreases each toolchain by ~50Mb.
- moved `nightly` Rust installation to the images that actually using it
- started changing labels to the "best practices" recommendations
- some lints

Tested on [Substrate](https://gitlab.parity.io/parity/substrate/pipelines/95067), [ink!](https://gitlab.parity.io/parity/ink/pipelines/94949) and [pallet-waterfalls](https://gitlab.parity.io/parity/pallet-contracts-waterfall/-/jobs/536719) CIs.

`base-ci-linux` image size went down from 475Mb to 325Mb
`ink-ci-linux`           740Mb -> 540Mb
`contracts-ci-linux` 840Mb -> 800Mb
`substrate-ci-linux` 1Gb -> 900Mb
