### PR TITLE
Rename substrate-ci-linux; 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,7 +65,7 @@ base-ci-linux:
     - *push_to_docker_hub
     - *push_to_own_reg
 
-substrate-ci-linux:
+ci-linux:
   <<:                              *docker_build
   script:
     - docker build --no-cache
@@ -246,14 +246,14 @@ container_scanning:
   tags:
     - kubernetes-parity-build
 
-test-substrate:
+ci-linux-test:
   stage:                           test
   image:                           $REGISTRY_PATH/$IMAGE_NAME:staging
   interruptible:                   true
   dependencies:                    []
   only:
     variables:
-      - $IMAGE_NAME == "substrate-ci-linux"
+      - $IMAGE_NAME == "ci-linux"
   variables:
     <<:                            *default-vars
     GIT_STRATEGY:                  none
@@ -280,7 +280,7 @@ test-substrate:
 
 #### stage:                        prod
 
-production-substrate:
+ci-linux-production:
   stage:                           prod
   image:                           docker:stable
   dependencies:                    []
@@ -288,7 +288,7 @@ production-substrate:
     - docker:dind
   only:
     variables:
-      - $IMAGE_NAME == "substrate-ci-linux"
+      - $IMAGE_NAME == "ci-linux"
   script:
     - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
     - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
@@ -296,6 +296,7 @@ production-substrate:
     - docker pull $REGISTRY_PATH/$IMAGE_NAME:staging
     - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:production
     - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+    - docker tag parity/rust-builder:latest
     - docker push $REGISTRY_PATH/$IMAGE_NAME:production
     - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
     - docker logout

--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -5,15 +5,17 @@ ARG REGISTRY_PATH=paritytech
 FROM ${REGISTRY_PATH}/base-ci-linux:latest
 
 # metadata
-LABEL io.parity.image.authors="devops-team@parity.io" \
-	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="${REGISTRY_PATH}/substrate-ci-linux" \
-	io.parity.image.description="Inherits from base-ci-linux; chromium-driver, \
+LABEL summary="Image for Substrate-based projects." \
+	name="${REGISTRY_PATH}/ci-linux" \
+	maintainer="devops-team@parity.io" \
+	version="1.0" \
+	description="Inherits from base-ci-linux; chromium-driver, \
 wasm-gc, wasm-bindgen-cli, wasm-pack, cargo-audit, cargo-web, cargo-deny " \
+	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
-dockerfiles/substrate-ci-linux/Dockerfile" \
+dockerfiles/ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
-dockerfiles/substrate-ci-linux/README.md" \
+dockerfiles/ci-linux/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 

--- a/dockerfiles/ci-linux/README.md
+++ b/dockerfiles/ci-linux/README.md
@@ -1,4 +1,4 @@
-# substrate-ci-linux
+# ci-linux
 
 Docker image based on our base CI image `<base-ci-linux:latest>`.
 
@@ -38,14 +38,14 @@ Used to build and test Substrate-based projects.
 - `cargo-deny`
 - `wasm32-unknown-unknown` toolchain
 
-[Click here](https://hub.docker.com/repository/docker/paritytech/substrate-ci-linux) for the registry.
+[Click here](https://hub.docker.com/repository/docker/paritytech/ci-linux) for the registry.
 
 ## Usage
 
 ```yaml
 test-substrate:
     stage: test
-        image: paritytech/substrate-ci-linux
+        image: paritytech/ci-linux
         script:
             - cargo build ...
 ```


### PR DESCRIPTION
and temporary publishing to the old `parity/rust-builder:latest` image.