### PR TITLE
Add jq to base-ci-linux

### DIFF
--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -38,7 +38,7 @@ RUN set -eux; \
 	apt-get -y update; \
 	apt-get install -y --no-install-recommends \
 		libssl-dev clang lld libclang-dev make cmake \
-		git pkg-config curl time rhash ca-certificates; \
+		git pkg-config curl time rhash ca-certificates jq; \
 # set a link to clang
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
 # install rustup, use minimum components


### PR DESCRIPTION
Not sure why `jq` wasn't already in our base image, but I think it should be. It's a small package and is super useful to have available in any CI job where we might want to read stuff from Github.

Ref: https://github.com/paritytech/polkadot/pull/1455#issuecomment-662490147