### PR TITLE
Add bash to awscli image

### DIFF
--- a/dockerfiles/awscli/Dockerfile
+++ b/dockerfiles/awscli/Dockerfile
@@ -17,6 +17,7 @@ dockerfiles/awscli/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 RUN pip install awscli
+RUN apk add bash
 
 COPY utility/awscli-config /etc/aws.config
 ENV AWS_CONFIG_FILE /etc/aws.config

--- a/dockerfiles/awscli/Dockerfile
+++ b/dockerfiles/awscli/Dockerfile
@@ -17,7 +17,7 @@ dockerfiles/awscli/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 RUN pip install awscli
-RUN apk add bash
+RUN apk add --no-cache bash
 
 COPY utility/awscli-config /etc/aws.config
 ENV AWS_CONFIG_FILE /etc/aws.config


### PR DESCRIPTION
Due to [this](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/1550) bug in gitlab-runner, a non-POSIX feature is used even when the shell is not `bash`. I {am using|will use} this image to push release-candidate builds to S3 on the cleanroom (see [this](https://gitlab.parity.io/s3krit/cleanroom/-/tree/gitlab-runner/ansible/roles/polkadot/files/gitlab-runner) branch or just ask me if you're curious about the progress of that), so run into this issue.

The actual issue is with the [`set -eo pipefail`](https://gitlab.com/gitlab-org/gitlab-runner/-/blob/master/shells/bash.go#L224) - some POSIX shells *do* seem to support this (or at least don't error when setting it), such as busybox's shell. So far I've only ran into `dash` that will actually error when attempting it.