### PR TITLE
new nightly installation, various optimizations and lints

### DIFF
--- a/dockerfiles/awscli/Dockerfile
+++ b/dockerfiles/awscli/Dockerfile
@@ -16,10 +16,10 @@ dockerfiles/awscli/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
-RUN pip install awscli
-RUN apk add --no-cache bash
+RUN pip install awscli; \
+	apk add --no-cache bash
 
 COPY utility/awscli-config /etc/aws.config
 ENV AWS_CONFIG_FILE /etc/aws.config
 
-CMD /bin/sh
+CMD ["/bin/sh"]

--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -39,8 +39,8 @@ RUN set -eux; \
 # set a link to clang
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
 # install rustup, use minimum components
-	curl "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
-		-Lo rustup-init; \
+	curl -L "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
+		-o rustup-init; \
   	chmod +x rustup-init; \
   	./rustup-init -y --no-modify-path --profile minimal --default-toolchain stable; \
   	rm rustup-init; \

--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -30,9 +30,6 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 		CC=clang \
 		CXX=clang
 
-# download rustup
-ADD "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" rustup-init
-
 # install tools and dependencies
 RUN set -eux; \
 	apt-get -y update; \
@@ -42,22 +39,20 @@ RUN set -eux; \
 # set a link to clang
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
 # install rustup, use minimum components
+	curl "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
+		-Lo rustup-init; \
   	chmod +x rustup-init; \
   	./rustup-init -y --no-modify-path --profile minimal --default-toolchain stable; \
   	rm rustup-init; \
-  	chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+  	chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}; \
 # install sccache
-	# FIXME: TEMPORARY OVERRIDE
-	# cargo install sccache --features redis; \
-	cargo install --git https://github.com/mozilla/sccache --features redis; \
+	cargo install sccache --features redis; \
 # versions
 	rustup show; \
 	cargo --version; \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
-	rm -rf $CARGO_HOME/registry; \
-# removes toolchain's html docs and autocompletions (>300M for each toolchain)
-	rm -rf /usr/local/rustup/toolchains/*/share; \
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \

--- a/dockerfiles/chaostools/Dockerfile
+++ b/dockerfiles/chaostools/Dockerfile
@@ -19,8 +19,8 @@ dockerfiles/chaostools/README.md" \
 
 RUN apk add --no-cache \
 		ca-certificates git jq make curl gettext; \
-	curl "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
-		-Lo /usr/local/bin/kubectl; \
+	curl -L "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
+		-o /usr/local/bin/kubectl; \
 	chmod +x /usr/local/bin/kubectl;
 
 WORKDIR /config

--- a/dockerfiles/chaostools/Dockerfile
+++ b/dockerfiles/chaostools/Dockerfile
@@ -8,7 +8,7 @@ ARG KUBE_VERSION="1.18.2"
 # metadata
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
-	io.parity.image.title="${REGISTRY_PATH}/kubetools" \
+	io.parity.image.title="${REGISTRY_PATH}/chaostools" \
 	io.parity.image.description="ca-certificates git jq make curl gettext; kube helm;" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/chaostools/Dockerfile" \
@@ -17,13 +17,12 @@ dockerfiles/chaostools/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
-ADD "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
-	/usr/local/bin/kubectl
-
 RUN apk add --no-cache \
 		ca-certificates git jq make curl gettext; \
+	curl "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
+		-Lo /usr/local/bin/kubectl; \
 	chmod +x /usr/local/bin/kubectl;
 
 WORKDIR /config
 
-CMD /bin/sh
+CMD ["/bin/sh"]

--- a/dockerfiles/chaostools/Dockerfile
+++ b/dockerfiles/chaostools/Dockerfile
@@ -9,7 +9,7 @@ ARG KUBE_VERSION="1.18.2"
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/chaostools" \
-	io.parity.image.description="ca-certificates git jq make curl gettext; kube helm;" \
+	io.parity.image.description="ca-certificates git jq make curl gettext; kube" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/chaostools/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -24,15 +24,13 @@ RUN set -eux; \
 	apt-get -y update; \
 	apt-get install -y --no-install-recommends \
 		chromium-driver; \
-# use minimum components
-	rustup set profile minimal; \
-# install Rust nightly, default is stable
-	rustup install nightly; \
-# install cargo tools
-	cargo install cargo-audit cargo-web wasm-pack cargo-deny wasm-bindgen-cli; \
+# install Rust nightly, default is stable, use minimum components
+	rustup toolchain install nightly --profile minimal; \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown; \
 	rustup target add wasm32-unknown-unknown --toolchain nightly; \
+# install cargo tools
+	cargo install cargo-audit cargo-web wasm-pack cargo-deny wasm-bindgen-cli; \
 # install wasm-gc. It's useful for stripping slimming down wasm binaries (polkadot)
 	cargo +nightly install wasm-gc; \
 # versions
@@ -44,6 +42,4 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*; \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
-	rm -rf $CARGO_HOME/registry; \
-# removes toolchain's html docs and autocompletions (>300M for each toolchain)
-	rm -rf /usr/local/rustup/toolchains/*/share
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache;

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -42,7 +42,6 @@ RUN set -eux; \
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
 			--profile minimal --component rustfmt rust-src; \
 	rustup default nightly; \
-	# rustup component add rustfmt; \
 	cargo install pwasm-utils-cli --bin wasm-prune; \
 	cargo install cargo-contract; \
 	cargo install --git https://github.com/hyperledger-labs/solang --tag m7; \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -8,8 +8,9 @@ FROM ${REGISTRY_PATH}/base-ci-linux:latest
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
-	io.parity.image.description="Inherits from base-ci-linux:latest. rust nightly, \
-llvm-8-dev, clang-8, zlib1g-dev, npm, yarn, wabt, unzip" \
+	io.parity.image.description="Inherits from base-ci-linux:latest. \
+llvm-8-dev, clang-8, zlib1g-dev, npm, yarn, wabt, unzip. \
+rust nightly, rustfmt, rust-src" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -36,15 +37,12 @@ RUN set -eux; \
 # set a link to clang-8
 	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100; \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100; \
-# use minimum components
-	rustup set profile minimal; \
-# install nightly Rust
-	rustup default nightly-2020-10-01; \
-# install wasm toolchain
-	rustup target add wasm32-unknown-unknown --toolchain nightly-2020-10-01; \
-# install cargo tools
-	rustup component add rustfmt; \
-	rustup component add rust-src rustfmt --toolchain nightly-2020-10-01; \
+# Installs the latest common nightly for the listed components,
+# adds those components, wasm target and sets the profile to minimal
+	rustup toolchain install nightly --target wasm32-unknown-unknown \
+			--profile minimal --component rustfmt rust-src; \
+	rustup default nightly; \
+	# rustup component add rustfmt; \
 	cargo install pwasm-utils-cli --bin wasm-prune; \
 	cargo install cargo-contract; \
 	cargo install --git https://github.com/hyperledger-labs/solang --tag m7; \
@@ -55,9 +53,7 @@ RUN set -eux; \
 	solang --version; \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
-	rm -rf "$CARGO_HOME/registry"; \
-# removes toolchain's html docs and autocompletions (>300M for each toolchain)
-	rm -rf /usr/local/rustup/toolchains/*/share; \
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \
 # apt clean up
 	apt-get autoremove -y; \
 	apt-get clean; \

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -30,21 +30,17 @@ Used to build and test contracts!.
 
 **Rust versions:**
 
-We always try to use the latest possible `nightly` version that supports our required `rustup` components:
+We always use the latest possible `nightly` version that supports our required `rustup` components:
 
-- `clippy`
-- `cargo`
-- `rustfmt`
-
-The [`rustup` component history](https://rust-lang.github.io/rustup-components-history/) provides a decent overview to decide upon a new version update.
+- `rustfmt`: The Rust code formatter.
+- `rust-src`: The Rust sources of the standard library.
 
 **Rust tools & toolchains:**
 
-- `rustfmt`
 - `cargo-contract`
 - `pwasm-utils-cli`
 - `solang`
-- `wasm32-unknown-unknown` toolchain
+- `wasm32-unknown-unknown`: The toolchain to compile Rust codebases for Wasm.
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/contracts-ci-linux) for the registry.
 

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -30,7 +30,7 @@ Used to build and test contracts!.
 
 **Rust versions:**
 
-We always use the latest possible `nightly` version that supports our required `rustup` components:
+We always try to use the [latest possible](https://rust-lang.github.io/rustup-components-history/) `nightly` version that supports our required `rustup` components:
 
 - `rustfmt`: The Rust code formatter.
 - `rust-src`: The Rust sources of the standard library.

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/ink-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
-rust nightly, clippy, rustfmt, cargo-kcov, cargo-contract" \
+rust nightly, clippy, rustfmt, miri, rust-src grcov, rust-covfix, cargo-contract, xargo" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/ink-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -32,20 +32,16 @@ RUN	set -eux; \
 # Only Rust nightly builds supporting all of the above mentioned components
 # and targets can be used for this docker image.
 #
-# Visit https://rust-lang.github.io/rustup-components-history/ to see which
-# components are available for which nightly build.
-# use minimum components
-	rustup set profile minimal; \
-	rustup default nightly-2020-10-08; \
-	# Install wasm32 target for this toolchain
-	rustup target add wasm32-unknown-unknown; \
-	rustup component add rustfmt clippy miri rust-src; \
+# Installs the latest common nightly for the listed components,
+# adds those components, wasm target and sets the profile to minimal
+	rustup toolchain install nightly --target wasm32-unknown-unknown \
+			--profile minimal --component rustfmt clippy miri rust-src; \
+	rustup default nightly; \
 	# We require `xargo` so that `miri` runs properly
 	# We require `grcov` for coverage reporting and `rust-covfix` to improve it.
 	cargo install grcov rust-covfix cargo-contract xargo; \
 	rustup show; \
 	cargo --version; \
 	# Clean up and remove compilation artifacts that a cargo install creates (>250M).
-	# Also removes toolchain's HTML, docs and autocompletions (>300M for each toolchain).
-	rm -rf "$CARGO_HOME/registry"; \
-	rm -rf /usr/local/rustup/toolchains/*/share;
+	rm -rf "${CARGO_HOME}/registry"; \
+	rm -rf /root/.cache/sccache;

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -37,11 +37,10 @@ RUN	set -eux; \
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
 			--profile minimal --component rustfmt clippy miri rust-src; \
 	rustup default nightly; \
-	# We require `xargo` so that `miri` runs properly
-	# We require `grcov` for coverage reporting and `rust-covfix` to improve it.
+# We require `xargo` so that `miri` runs properly
+# We require `grcov` for coverage reporting and `rust-covfix` to improve it.
 	cargo install grcov rust-covfix cargo-contract xargo; \
 	rustup show; \
 	cargo --version; \
-	# Clean up and remove compilation artifacts that a cargo install creates (>250M).
-	rm -rf "${CARGO_HOME}/registry"; \
-	rm -rf /root/.cache/sccache;
+# Clean up and remove compilation artifacts that a cargo install creates (>250M).
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache;

--- a/dockerfiles/ink-ci-linux/README.md
+++ b/dockerfiles/ink-ci-linux/README.md
@@ -23,7 +23,7 @@ Used to build and test ink!.
 
 **Rust versions:**
 
-We always use the latest possible `nightly` version that supports our required `rustup` components:
+We always try to use the [latest possible](https://rust-lang.github.io/rustup-components-history/) `nightly` version that supports our required `rustup` components:
 
 - `clippy`: The Rust linter.
 - `rust-src`: The Rust sources of the standard library.

--- a/dockerfiles/ink-ci-linux/README.md
+++ b/dockerfiles/ink-ci-linux/README.md
@@ -23,15 +23,12 @@ Used to build and test ink!.
 
 **Rust versions:**
 
-We always try to use the latest possible `nightly` version that supports our required `rustup` components:
+We always use the latest possible `nightly` version that supports our required `rustup` components:
 
 - `clippy`: The Rust linter.
 - `rust-src`: The Rust sources of the standard library.
 - `miri`: The Rust MIR interpreter that interprets the test suite with additional checks.
-- `cargo`: The Rust build system.
 - `rustfmt`: The Rust code formatter.
-
-The [`rustup` component history](https://rust-lang.github.io/rustup-components-history/) provides a decent overview to decide upon a new version update.
 
 **Rust tools & toolchains:**
 

--- a/dockerfiles/kubetools/Dockerfile
+++ b/dockerfiles/kubetools/Dockerfile
@@ -18,15 +18,16 @@ dockerfiles/kubetools/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
-ADD "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
-	/usr/local/bin/kubectl
-RUN wget -q "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -O - | tar -xzO linux-amd64/helm \
-	> /usr/local/bin/helm
 RUN apk add --no-cache \
 		ca-certificates git jq make curl gettext; \
+		tar xvz linux-amd64/helm > /usr/local/bin/helm; \
+	curl "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
+		-Lo /usr/local/bin/kubectl; \
+	curl -L0 "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | \
+		tar xzO linux-amd64/helm > /usr/local/bin/helm; \
 	chmod +x /usr/local/bin/kubectl; \
 	chmod +x /usr/local/bin/helm
 
 WORKDIR /config
 
-CMD /bin/sh
+CMD ["/bin/sh"]

--- a/dockerfiles/kubetools/Dockerfile
+++ b/dockerfiles/kubetools/Dockerfile
@@ -21,7 +21,6 @@ dockerfiles/kubetools/README.md" \
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
 		ca-certificates git jq make curl gettext; \
-		tar xvz linux-amd64/helm > /usr/local/bin/helm; \
 	curl "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
 		-Lo /usr/local/bin/kubectl; \
 	curl -L0 "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | \

--- a/dockerfiles/kubetools/Dockerfile
+++ b/dockerfiles/kubetools/Dockerfile
@@ -18,13 +18,15 @@ dockerfiles/kubetools/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
 		ca-certificates git jq make curl gettext; \
-	curl "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
-		-Lo /usr/local/bin/kubectl; \
-	curl -L0 "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | \
-		tar xzO linux-amd64/helm > /usr/local/bin/helm; \
+	curl -L "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
+		-o /usr/local/bin/kubectl; \
+	curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
+		-o helm.tar.gz; \
+	tar -zxf helm.tar.gz linux-amd64/helm; \
+	mv linux-amd64/helm /usr/local/bin/helm; \
+	rm -rf helm.tar.gz linux-amd64; \
 	chmod +x /usr/local/bin/kubectl; \
 	chmod +x /usr/local/bin/helm
 

--- a/dockerfiles/kubetools/Dockerfile
+++ b/dockerfiles/kubetools/Dockerfile
@@ -18,6 +18,7 @@ dockerfiles/kubetools/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 RUN apk add --no-cache \
 		ca-certificates git jq make curl gettext; \
 		tar xvz linux-amd64/helm > /usr/local/bin/helm; \

--- a/dockerfiles/redis-exporter/Dockerfile
+++ b/dockerfiles/redis-exporter/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.13-alpine as builder
 RUN apk --no-cache add ca-certificates git
 
 RUN go get github.com/oliver006/redis_exporter
-RUN cd $GOPATH/src/github.com/oliver006/redis_exporter && go build
+RUN cd ${GOPATH}/src/github.com/oliver006/redis_exporter && go build
 
 
 FROM alpine as alpine

--- a/dockerfiles/terraform/Dockerfile
+++ b/dockerfiles/terraform/Dockerfile
@@ -17,15 +17,14 @@ dockerfiles/terraform/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
-ADD "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" /tmp
-RUN unzip /tmp/terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin/ terraform && \
-	rm /tmp/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-
-
 RUN apk add --no-cache \
 		ca-certificates git jq make curl gettext; \
+	curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
+		-o terraform.zip; \
+	unzip terraform.zip	-d /usr/local/bin/ terraform; \
+	rm terraform.zip; \
 	chmod +x /usr/local/bin/terraform
 
 WORKDIR /config
 
-CMD /bin/sh
+CMD ["/bin/sh"]

--- a/dockerfiles/tools/Dockerfile
+++ b/dockerfiles/tools/Dockerfile
@@ -21,10 +21,10 @@ dockerfiles/tools/README.md" \
 
 RUN apk add --no-cache curl git jq rsync make gettext gnupg bash
 
-RUN curl -sS -L https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz \
-  --output prometheus.tar.gz && \
+RUN curl -sS -L "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz" \
+  		--output prometheus.tar.gz && \
 	tar -xzf prometheus.tar.gz prometheus-${PROM_VERSION}.linux-amd64/promtool && \
 	mv prometheus-${PROM_VERSION}.linux-amd64/promtool /usr/local/bin && \
 	rm -rf prometheus.tar.gz prometheus-${PROM_VERSION}.linux-amd64
 
-CMD /bin/sh
+CMD ["/bin/sh"]


### PR DESCRIPTION
The most important change is that rustup searches the latest common `nightly` Rust version for the list of the given components. This removes the need in the frequent PRs to update the nightly version for `ink` or `contracts`.

Second valuable point is that previously I was removing the build-in docs and help from each toolchain, and it was worth it. The economy was ~150 Mb per a toolchain. But it potentially lead to some troubles with `rustup`. AAMF it couldn't update and do things with toolchains due to it wanted to remove the old stuff and couldn't find it. Nevertheless we are not updating stuff in the images, it could potentially lead to some other wierd stuff. Thankfully, `--profile minimal` does nearly the same.

Also I realized that `cargo install` within the image build time produces some cache inside the image (hundreds of Mb) so I've optimized the way we clean up.

Other than that I leveraged some dockerfiles lints and best practices like
- `curl` is better than `ADD`
- `curl` is better than `wget`
- pipelining within Dockerfiles can lead to errors baked in
- `CMD` and `ENTRYPOINT` should be `[""]`d