### PR TITLE
change (dockerfile): return to workaround sccache's bug

### DIFF
--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -46,7 +46,10 @@ RUN set -eux; \
   	rm rustup-init; \
   	chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}; \
 # install sccache
-	cargo install sccache --features redis; \
+	# cargo install sccache --features redis; \
+	# FIXME: TEMPORARY OVERRIDE due to the sccache issue
+	# https://github.com/mozilla/sccache/issues/663
+	cargo install --git https://github.com/mozilla/sccache --features redis; \
 # versions
 	rustup show; \
 	cargo --version; \

--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -49,7 +49,7 @@ RUN set -eux; \
 	# cargo install sccache --features redis; \
 	# FIXME: TEMPORARY OVERRIDE due to the sccache issue
 	# https://github.com/mozilla/sccache/issues/663
-	cargo install --git https://github.com/mozilla/sccache --features redis; \
+	cargo install --git https://github.com/mozilla/sccache  --rev 6628e1f70db3d583cb5e79210603ad878de3d315 --features redis; \
 # versions
 	rustup show; \
 	cargo --version; \


### PR DESCRIPTION
Still waiting until https://github.com/mozilla/sccache/issues/663 will be merged, having

```
    Compiling futures-channel v0.3.5
  error[E0514]: found crate `hash_db` compiled by an incompatible version of rustc
    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/trie-root-0.16.0/src/lib.rs:41:9
     |
  41 | pub use hash_db::Hasher;
     |         ^^^^^^^
     |
     = help: please recompile that crate using this compiler (rustc 1.49.0-nightly (b20253260 2020-11-01))
     = note: the following crate versions were found:
             crate `hash_db` compiled by rustc 1.49.0-nightly (ffe52882e 2020-10-30): /builds/parity/substrate/target/release/wbuild/target/wasm32-unknown-unknown/release/deps/libhash_db-7abf16653d25fc04.rmeta
```
randomly.