### PR TITLE
Update solang and canvas-node in contracts CI image

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -20,6 +20,8 @@ dockerfiles/contracts-ci-linux/README.md" \
 
 WORKDIR /builds
 
+ENV CXX="/usr/bin/clang++-8"
+
 # copy llvm and yarn repo key
 COPY utility/yarn.key /etc/apt/trusted.gpg.d/debian-yarn.gpg
 
@@ -27,18 +29,25 @@ COPY utility/yarn.key /etc/apt/trusted.gpg.d/debian-yarn.gpg
 RUN set -eux; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main"  \
 		> /etc/apt/sources.list.d/yarn.list; \
+	echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
+		> /etc/apt/sources.list.d/llvm.list; \
+	echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
+		>> /etc/apt/sources.list.d/llvm.list; \
 	apt-get -y update; \
 	apt-get remove -y --purge clang; \
 	apt-get install -y --no-install-recommends \
-		npm yarn wabt; \
+		llvm-8-dev clang-8 npm yarn wabt; \
+# set a link to clang-8
+	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100; \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100; \
+	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 100; \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
-			--profile minimal --component rustfmt rust-src; \
+		--profile minimal --component rustfmt rust-src; \
 	rustup default nightly; \
 	cargo install pwasm-utils-cli --bin wasm-prune; \
 	cargo install cargo-contract; \
-	cargo install --git https://github.com/paritytech/canvas-node --tag v0.1.2; \
 # versions
 	yarn --version; \
 	rustup show; \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -20,6 +20,8 @@ dockerfiles/contracts-ci-linux/README.md" \
 
 WORKDIR /builds
 
+ENV SHELL /bin/bash
+
 ENV CXX="/usr/bin/clang++-8"
 
 # copy llvm and yarn repo key

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /builds
 ENV CXX="/usr/bin/clang++-8"
 
 # copy llvm and yarn repo key
+COPY utility/debian-llvm-clang.key /etc/apt/trusted.gpg.d/debian-archive-llvm.gpg
 COPY utility/yarn.key /etc/apt/trusted.gpg.d/debian-yarn.gpg
 
 # install tools and dependencies

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
-llvm-8-dev, clang-8,  zlib1g-dev, npm, yarn, wabt. \
+llvm-8-dev, clang-8, python3, zlib1g-dev, npm, yarn, wabt. \
 rust nightly, rustfmt, rust-src, solang, canvas-node" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
@@ -39,8 +39,9 @@ RUN set -eux; \
 	apt-get -y update; \
 	apt-get remove -y --purge clang; \
 	apt-get install -y --no-install-recommends \
-		 zlib1g-dev llvm-8-dev clang-8 npm yarn wabt; \
-# set a link to clang-8
+		 zlib1g-dev llvm-8-dev clang-8 python3 npm yarn wabt; \
+# set links to clang-8 and python3
+	update-alternatives --install /usr/bin/python python /usr/bin/python3 100; \
 	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100; \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100; \
 	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 100; \
@@ -51,7 +52,7 @@ RUN set -eux; \
 	rustup default nightly; \
 	cargo install pwasm-utils-cli --bin wasm-prune; \
 	cargo install cargo-contract; \
-	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.2; \
+	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.5; \
 # download the latest canvas-node binary
 	curl -L "https://gitlab.parity.io/parity/canvas-node/-/jobs/artifacts/master/raw/artifacts/canvas/canvas?job=build" \
 		-o /usr/local/cargo/bin/canvas; \
@@ -62,6 +63,7 @@ RUN set -eux; \
 	cargo --version; \
 	solang --version; \
 	canvas --version; \
+	python --version; \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
-llvm-8-dev, clang-8, zlib1g-dev, npm, yarn, wabt, unzip. \
+zlib1g-dev, npm, yarn, wabt, unzip. \
 rust nightly, rustfmt, rust-src" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
@@ -18,25 +18,19 @@ dockerfiles/contracts-ci-linux/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
+WORKDIR /builds
+
 # copy llvm and yarn repo key
-COPY utility/debian-llvm-clang.key /etc/apt/trusted.gpg.d/debian-archive-llvm.gpg
 COPY utility/yarn.key /etc/apt/trusted.gpg.d/debian-yarn.gpg
 
 # install tools and dependencies
 RUN set -eux; \
 	echo "deb https://dl.yarnpkg.com/debian/ stable main"  \
 		> /etc/apt/sources.list.d/yarn.list; \
-	echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
-		> /etc/apt/sources.list.d/llvm.list; \
-	echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
-		>> /etc/apt/sources.list.d/llvm.list; \
 	apt-get -y update; \
 	apt-get remove -y --purge clang; \
 	apt-get install -y --no-install-recommends \
-		llvm-8-dev clang-8 zlib1g-dev npm yarn wabt unzip; \
-# set a link to clang-8
-	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100; \
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100; \
+		npm yarn wabt; \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
@@ -44,13 +38,11 @@ RUN set -eux; \
 	rustup default nightly; \
 	cargo install pwasm-utils-cli --bin wasm-prune; \
 	cargo install cargo-contract; \
-	cargo install --git https://github.com/hyperledger-labs/solang --tag m7; \
 	cargo install --git https://github.com/paritytech/canvas-node --tag v0.1.2; \
 # versions
 	yarn --version; \
 	rustup show; \
 	cargo --version; \
-	solang --version; \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -52,7 +52,8 @@ RUN set -eux; \
 	rustup default nightly; \
 	cargo install pwasm-utils-cli --bin wasm-prune; \
 	cargo install cargo-contract; \
-	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.5; \
+# tried v0.1.5 and the latest master - both fail with https://github.com/hyperledger-labs/solang/issues/314
+	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.2; \
 # download the latest canvas-node binary
 	curl -L "https://gitlab.parity.io/parity/canvas-node/-/jobs/artifacts/master/raw/artifacts/canvas/canvas?job=build" \
 		-o /usr/local/cargo/bin/canvas; \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
-zlib1g-dev, npm, yarn, wabt, unzip. \
+llvm-8-dev, clang-8, npm, yarn, wabt. \
 rust nightly, rustfmt, rust-src" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
-llvm-8-dev, clang-8, npm, yarn, wabt. \
+llvm-8-dev, clang-8,  zlib1g-dev, npm, yarn, wabt. \
 rust nightly, rustfmt, rust-src, solang, canvas-node" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
@@ -37,7 +37,7 @@ RUN set -eux; \
 	apt-get -y update; \
 	apt-get remove -y --purge clang; \
 	apt-get install -y --no-install-recommends \
-		llvm-8-dev clang-8 npm yarn wabt; \
+		 zlib1g-dev llvm-8-dev clang-8 npm yarn wabt; \
 # set a link to clang-8
 	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100; \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100; \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -10,7 +10,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
 llvm-8-dev, clang-8, npm, yarn, wabt. \
-rust nightly, rustfmt, rust-src" \
+rust nightly, rustfmt, rust-src, solang, canvas-node" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -49,10 +49,17 @@ RUN set -eux; \
 	rustup default nightly; \
 	cargo install pwasm-utils-cli --bin wasm-prune; \
 	cargo install cargo-contract; \
+	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.2; \
+# download the latest canvas-node binary
+	curl -L "https://gitlab.parity.io/parity/canvas-node/-/jobs/artifacts/master/raw/artifacts/canvas/canvas?job=build" \
+		-o /usr/local/cargo/bin/canvas; \
+	chmod +x /usr/local/cargo/bin/canvas; \
 # versions
 	yarn --version; \
 	rustup show; \
 	cargo --version; \
+	solang --version; \
+	canvas --version; \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -9,6 +9,7 @@ Used to build and test contracts!.
 - `llvm-8-dev`
 - `clang-8`
 - `zlib1g-dev`
+- `python3`
 - `npm`
 - `yarn`
 - `wabt`

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -12,7 +12,6 @@ Used to build and test contracts!.
 - `npm`
 - `yarn`
 - `wabt`
-- `unzip`
 
 **Inherited from `<base-ci-linux:latest>`:**
 

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -40,6 +40,7 @@ We always try to use the [latest possible](https://rust-lang.github.io/rustup-co
 - `cargo-contract`
 - `pwasm-utils-cli`
 - `solang`
+- `canvas-node`
 - `wasm32-unknown-unknown`: The toolchain to compile Rust codebases for Wasm.
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/contracts-ci-linux) for the registry.

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -17,6 +17,8 @@ dockerfiles/ink-ci-linux/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
+WORKDIR /builds
+
 RUN	set -eux; \
 # The supported Rust nightly version must support the following components
 # to allow for a functioning CI pipeline:


### PR DESCRIPTION
> Can't be merged until https://github.com/paritytech/canvas-node/issues/21 is resolved, this will break the `test` job in `cargo-contracts` CI. Other than that, `fmt` and `build` are successful.

Temporary workaround: https://github.com/paritytech/cargo-contract/pull/114

- `solang` update to `v0.1.2`, newer versions did not work
- `canvas`-node binary included as an artifact from the latest master
- `clang-8` set as a linker
- `python3` set as default

Closes paritytech/ci_cd#1 
Closes paritytech/ci_cd#18