### PR TITLE
Trigger contracts CI to test the image against master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -280,6 +280,9 @@ ci-linux-test:
 
 contracts-ci-linux-test:
   stage:                           test
+  only:
+    variables:
+      - $IMAGE_NAME == "contracts-ci-linux"
   needs:
     - job:                         contracts-ci-linux
       artifacts:                   false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -274,11 +274,13 @@ ci-linux-test:
 
 contracts-ci-linux-test:
   stage:                           test
+  variables:
+    CI_IMAGE:                      "paritytech/contracts-ci-linux:staging"
   rules:
     - if: $IMAGE_NAME == "contracts-ci-linux"
   trigger:
     project:                       parity/cargo-contract
-    branch:                        master
+    branch:                        "115"
     strategy:                      depend
 
 #### stage:                        prod

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,19 +31,31 @@ default:
 
 # Push to Dockerhub
 .push_to_docker_hub:               &push_to_docker_hub
-    - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-    - docker build --no-cache
+  - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
+  - docker build --no-cache
+      --build-arg VCS_REF="$CI_COMMIT_SHA"
+      --build-arg BUILD_DATE="$(date +%Y%m%d)"
+      --build-arg REGISTRY_PATH=$REGISTRY_PATH
+      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+      --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
+  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
+  - docker info
+  - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+  - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+  - docker logout
+
+.push_to_staging:                  &push_to_staging
+  - docker build
         --build-arg VCS_REF="$CI_COMMIT_SHA"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
         --build-arg REGISTRY_PATH=$REGISTRY_PATH
-        --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-        --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+        --tag $REGISTRY_PATH/$IMAGE_NAME:staging
         --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
-    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-    - docker info
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-    - docker logout
+  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
+  - docker info
+  - docker push $REGISTRY_PATH/$IMAGE_NAME:staging
+  - docker logout
 
 #### stage:                        build
 
@@ -56,16 +68,7 @@ base-ci-linux:
 ci-linux:
   <<:                              *docker_build
   script:
-    - docker build --no-cache
-        --build-arg VCS_REF="$CI_COMMIT_SHA"
-        --build-arg BUILD_DATE="$(date +%Y%m%d)"
-        --build-arg REGISTRY_PATH=$REGISTRY_PATH
-        --tag $REGISTRY_PATH/$IMAGE_NAME:staging
-        --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
-    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-    - docker info
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:staging
-    - docker logout
+    - *push_to_staging
 
 ink-ci-linux:
   <<:                              *docker_build
@@ -75,7 +78,7 @@ ink-ci-linux:
 contracts-ci-linux:
   <<:                              *docker_build
   script:
-    - *push_to_docker_hub
+    - *push_to_staging
 
 awscli:
   <<:                              *docker_build
@@ -264,17 +267,48 @@ ci-linux-test:
   tags:
     - linux-docker
 
+contracts-ci-linux-test:
+  stage:                           test
+  needs:
+    - job:                         contracts-ci-linux
+      artifacts:                   false
+  trigger:
+    project:                       parity/cargo-contracts
+    branch:                        master
+    strategy:                      depend
+
 #### stage:                        prod
 
 ci-linux-production:
   stage:                           prod
   image:                           docker:stable
-  dependencies:                    []
   services:
     - docker:dind
   only:
     variables:
       - $IMAGE_NAME == "ci-linux"
+  script:
+    - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
+    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
+    - docker info
+    - docker pull $REGISTRY_PATH/$IMAGE_NAME:staging
+    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:production
+    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging parity/rust-builder:latest
+    - docker push $REGISTRY_PATH/$IMAGE_NAME:production
+    - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+    - docker logout
+  tags:
+    - kubernetes-parity-build
+
+contracts-ci-linux-production:
+  stage:                           prod
+  image:                           docker:stable
+  services:
+    - docker:dind
+  needs:
+    - job:                         contracts-ci-linux-test
+      artifacts:                   false
   script:
     - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
     - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -120,7 +120,7 @@ chaostools:
     - |
       cat <<-EOT
       |
-      | # build of chaostools image
+      | # build of chaostools image>
       |
       | KUBE_VERSION = $BUILD_KUBE_VERSION
       |
@@ -213,7 +213,7 @@ terraform:
 container_scanning:
   # Template does not work, had to override its config from
   # https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml
-  # these settings are from the template
+  # these settings are from the template 
   stage:                           test
   image:                           $SECURE_ANALYZERS_PREFIX/klar:$CS_MAJOR_VERSION
   services:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -280,7 +280,7 @@ contracts-ci-linux-test:
     - if: $IMAGE_NAME == "contracts-ci-linux"
   trigger:
     project:                       parity/cargo-contract
-    branch:                        "115"
+    branch:                        master
     strategy:                      depend
 
 #### stage:                        prod

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,12 +20,10 @@ default:
 .build:                            &docker_build
   stage:                           build
   image:                           docker:stable
-  dependencies:                    []
   services:
     - docker:dind
-  only:
-    variables:
-      - $IMAGE_NAME == $CI_JOB_NAME
+  rules:
+    - if: $IMAGE_NAME == $CI_JOB_NAME
   tags:
     - kubernetes-parity-build
 
@@ -222,7 +220,6 @@ container_scanning:
     - name:                        $CLAIR_DB_IMAGE
       alias:                       clair-vulnerabilities-db
   allow_failure:                   true
-  dependencies:                    []
   script:
     - /analyzer run
   artifacts:
@@ -239,9 +236,8 @@ container_scanning:
     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$IMAGE_NAME
     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
     DOCKERFILE_PATH:               dockerfiles/$IMAGE_NAME/Dockerfile
-  only:
-    variables:
-      - $IMAGE_NAME
+  rules:
+    - if: $IMAGE_NAME
   tags:
     - kubernetes-parity-build
 
@@ -249,10 +245,8 @@ ci-linux-test:
   stage:                           test
   image:                           $REGISTRY_PATH/$IMAGE_NAME:staging
   interruptible:                   true
-  dependencies:                    []
-  only:
-    variables:
-      - $IMAGE_NAME == "ci-linux"
+  rules:
+    - if: $IMAGE_NAME == "ci-linux"
   variables:
     <<:                            *default-vars
     GIT_STRATEGY:                  none
@@ -280,12 +274,8 @@ ci-linux-test:
 
 contracts-ci-linux-test:
   stage:                           test
-  only:
-    variables:
-      - $IMAGE_NAME == "contracts-ci-linux"
-  needs:
-    - job:                         contracts-ci-linux
-      artifacts:                   false
+  rules:
+    - if: $IMAGE_NAME == "contracts-ci-linux"
   trigger:
     project:                       parity/cargo-contract
     branch:                        master
@@ -298,9 +288,8 @@ ci-linux-production:
   image:                           docker:stable
   services:
     - docker:dind
-  only:
-    variables:
-      - $IMAGE_NAME == "ci-linux"
+  rules:
+    - if: $IMAGE_NAME == "ci-linux"
   script:
     - *push_to_production
   tags:
@@ -314,9 +303,8 @@ contracts-ci-linux-production:
   needs:
     - job:                         contracts-ci-linux-test
       artifacts:                   false
-  only:
-    variables:
-      - $IMAGE_NAME == "contracts-ci-linux"
+  rules:
+    - if: $IMAGE_NAME == "contracts-ci-linux"
   script:
     - *push_to_production
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -273,7 +273,7 @@ contracts-ci-linux-test:
     - job:                         contracts-ci-linux
       artifacts:                   false
   trigger:
-    project:                       parity/cargo-contracts
+    project:                       parity/cargo-contract
     branch:                        master
     strategy:                      depend
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,17 @@ default:
   - docker push $REGISTRY_PATH/$IMAGE_NAME:staging
   - docker logout
 
+.push_to_production:               &push_to_production
+  - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
+  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
+  - docker info
+  - docker pull $REGISTRY_PATH/$IMAGE_NAME:staging
+  - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:production
+  - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+  - docker push $REGISTRY_PATH/$IMAGE_NAME:production
+  - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+  - docker logout
+
 #### stage:                        build
 
 #Build and push to docker hub and CI registry
@@ -288,16 +299,7 @@ ci-linux-production:
     variables:
       - $IMAGE_NAME == "ci-linux"
   script:
-    - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-    - docker info
-    - docker pull $REGISTRY_PATH/$IMAGE_NAME:staging
-    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:production
-    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging parity/rust-builder:latest
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:production
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-    - docker logout
+    - *push_to_production
   tags:
     - kubernetes-parity-build
 
@@ -309,16 +311,10 @@ contracts-ci-linux-production:
   needs:
     - job:                         contracts-ci-linux-test
       artifacts:                   false
+  only:
+    variables:
+      - $IMAGE_NAME == "contracts-ci-linux"
   script:
-    - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-    - docker info
-    - docker pull $REGISTRY_PATH/$IMAGE_NAME:staging
-    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:production
-    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-    - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging parity/rust-builder:latest
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:production
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-    - docker logout
+    - *push_to_production
   tags:
     - kubernetes-parity-build


### PR DESCRIPTION
Contracts CI image is now tested against contract code every time the image is updated (nightly).

Pipeline 
1. Scripts CI builds `contracts-ci-linux:staging`
2. Runs container scan and
    Triggers the downstream Contracts CI pipeline for the master branch [to be executed in](https://gitlab.parity.io/parity/cargo-contract/-/jobs/732567#L4) `contracts-ci-linux:staging` image
3. If the test is green, `contracts-ci-linux:staging` gets published as `contracts-ci-linux:production`
    In the other case, It's easier for the developers to see the failed pipeline in their own CI rather than look into this one (which no one does).

A good example of the pipeline: https://gitlab.parity.io/parity/infrastructure/scripts/-/pipelines/115699

![image](https://user-images.githubusercontent.com/17856421/100789131-57174600-3416-11eb-98e8-5c2712dd47c2.png)

Companion PR: https://github.com/paritytech/cargo-contract/pull/115