### PR TITLE
Nightly tested ci images for sccache and ink

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,9 +82,14 @@ ci-linux:
 ink-ci-linux:
   <<:                              *docker_build
   script:
-    - *push_to_docker_hub
+    - *push_to_staging
 
 contracts-ci-linux:
+  <<:                              *docker_build
+  script:
+    - *push_to_staging
+
+sccache-ci-linux:
   <<:                              *docker_build
   script:
     - *push_to_staging
@@ -272,6 +277,17 @@ ci-linux-test:
   tags:
     - linux-docker
 
+ink-ci-linux-test:
+  stage:                           test
+  variables:
+    CI_IMAGE:                      "paritytech/ink-ci-linux:staging"
+  rules:
+    - if: $IMAGE_NAME == "ink-ci-linux"
+  trigger:
+    project:                       parity/ink
+    branch:                        master
+    strategy:                      depend
+
 contracts-ci-linux-test:
   stage:                           test
   variables:
@@ -280,6 +296,17 @@ contracts-ci-linux-test:
     - if: $IMAGE_NAME == "contracts-ci-linux"
   trigger:
     project:                       parity/cargo-contract
+    branch:                        master
+    strategy:                      depend
+
+sccache-ci-linux-test:
+  stage:                           test
+  variables:
+    CI_IMAGE:                      "paritytech/sccache-ci-linux:staging"
+  rules:
+    - if: $IMAGE_NAME == "sccache-ci-linux"
+  trigger:
+    project:                       parity/sccache
     branch:                        master
     strategy:                      depend
 
@@ -297,17 +324,34 @@ ci-linux-production:
   tags:
     - kubernetes-parity-build
 
-contracts-ci-linux-production:
+ink-ci-linux-production:           &push-after-triggered-pipeline
   stage:                           prod
   image:                           docker:stable
   services:
     - docker:dind
   needs:
-    - job:                         contracts-ci-linux-test
+    - job:                         ink-ci-linux-test
       artifacts:                   false
   rules:
-    - if: $IMAGE_NAME == "contracts-ci-linux"
+    - if: $IMAGE_NAME == "ink-ci-linux"
   script:
     - *push_to_production
   tags:
     - kubernetes-parity-build
+
+contracts-ci-linux-production:
+  <<:                              *push-after-triggered-pipeline
+  needs:
+    - job:                         contracts-ci-linux-test
+      artifacts:                   false
+  rules:
+    - if: $IMAGE_NAME == "contracts-ci-linux"
+  
+
+sccache-ci-linux-production:
+  <<:                              *push-after-triggered-pipeline
+  needs:
+    - job:                         sccache-ci-linux-test
+      artifacts:                   false
+  rules:
+    - if: $IMAGE_NAME == "sccache-ci-linux"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,7 +89,7 @@ contracts-ci-linux:
   script:
     - *push_to_staging
 
-sccache-ci-linux:
+sccache-ci-ubuntu:
   <<:                              *docker_build
   script:
     - *push_to_staging
@@ -299,12 +299,12 @@ contracts-ci-linux-test:
     branch:                        master
     strategy:                      depend
 
-sccache-ci-linux-test:
+sccache-ci-ubuntu-test:
   stage:                           test
   variables:
-    CI_IMAGE:                      "paritytech/sccache-ci-linux:staging"
+    CI_IMAGE:                      "paritytech/sccache-ci-ubuntu:staging"
   rules:
-    - if: $IMAGE_NAME == "sccache-ci-linux"
+    - if: $IMAGE_NAME == "sccache-ci-ubuntu"
   trigger:
     project:                       parity/sccache
     branch:                        master
@@ -348,10 +348,10 @@ contracts-ci-linux-production:
     - if: $IMAGE_NAME == "contracts-ci-linux"
   
 
-sccache-ci-linux-production:
+sccache-ci-ubuntu-production:
   <<:                              *push-after-triggered-pipeline
   needs:
-    - job:                         sccache-ci-linux-test
+    - job:                         sccache-ci-ubuntu-test
       artifacts:                   false
   rules:
-    - if: $IMAGE_NAME == "sccache-ci-linux"
+    - if: $IMAGE_NAME == "sccache-ci-ubuntu"


### PR DESCRIPTION
Same as in https://github.com/paritytech/scripts/pull/238 but for `ink` and `sccache` CI images

CI images are now tested against their target code every time the image is updated (nightly).

Pipeline example
1. Scripts CI builds `contracts-ci-linux:staging`
2. Runs container scan and
    Triggers the downstream Contracts CI pipeline for the master branch [to be executed in](https://gitlab.parity.io/parity/cargo-contract/-/jobs/732567#L4) `contracts-ci-linux:staging` image
3. If the test is green, `contracts-ci-linux:staging` gets published as `contracts-ci-linux:production`
    In the other case, It's easier for the developers to see the failed pipeline in their own CI rather than look into this one (which no one does).

A good example of the pipeline: https://gitlab.parity.io/parity/infrastructure/scripts/-/pipelines/115699

![image](https://user-images.githubusercontent.com/17856421/100789131-57174600-3416-11eb-98e8-5c2712dd47c2.png)

Companion PRs: https://github.com/paritytech/sccache/pull/25 https://github.com/paritytech/ink/pull/603