### PR TITLE
Buildah to build images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,14 +33,14 @@ default:
   - mkdir -p /kaniko/.docker
   - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"$(echo -n \"$DOCKER_USER\":\"$DOCKER_PASSWORD\" | base64)\"}}}" > /kaniko/.docker/config.json
   - /kaniko/executor
-      --cache true
+      --cache=true
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH=$REGISTRY_PATH
       --context dockerfiles
       --dockerfile dockerfiles/$IMAGE_NAME/Dockerfile
-      --destination docker.io/$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --destination docker.io/$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+      --destination=docker.io/$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+      --destination=docker.io/$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
   
 # # Push to Dockerhub
 # .push_to_docker_hub:               &push_to_docker_hub

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,14 +34,14 @@ default:
   - buildah bud --no-cache
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
-      --build-arg REGISTRY_PATH=$REGISTRY_PATH
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
+      --build-arg REGISTRY_PATH="$REGISTRY_PATH"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+      --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
   - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
-  - buildah push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-  - buildah push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-  - buildah logout
+  - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+  - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+  - buildah logout "$REGISTRY_PATH"
 
 
 # # Push to Dockerhub using kaniko

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ default:
 
 .build:                            &docker_build
   stage:                           build
-  image:                           docker:stable
+  image:                           docker:dind-rootless
   services:
     - docker:dind
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,6 @@ default:
   - mkdir -p /kaniko/.docker
   - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"$DOCKER_USER\",\"password\":\"$DOCKER_PASSWORD\"}}}" > /kaniko/.docker/config.json
   - /kaniko/executor
-      --cache=true
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH=$REGISTRY_PATH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,7 @@ default:
   - buildah version
   - buildah bud
       --squash
+      --format=docker
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -242,7 +242,6 @@ container_scanning:
     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$IMAGE_NAME
     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
     DOCKERFILE_PATH:               dockerfiles/$IMAGE_NAME/Dockerfile
-    REGISTRY_INSECURE:             "true"
   rules:
     - if: $IMAGE_NAME
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ default:
 .push_to_docker_hub:               &push_to_docker_hub
   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
   - mkdir -p /kaniko/.docker
-  - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"$(echo -n \"$DOCKER_USER\":\"$DOCKER_PASSWORD\" | base64)\"}}}" > /kaniko/.docker/config.json
+  - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"$DOCKER_USER\",\"password\":\"$DOCKER_PASSWORD\"}}}" > /kaniko/.docker/config.json
   - /kaniko/executor
       --cache=true
       --build-arg VCS_REF="$CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,14 +33,14 @@ default:
   - mkdir -p /kaniko/.docker
   - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"$(echo -n \"$DOCKER_USER\":\"$DOCKER_PASSWORD\" | base64)\"}}}" > /kaniko/.docker/config.json
   - /kaniko/executor
-      --cache=true
+      --cache true
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH=$REGISTRY_PATH
       --context dockerfiles
       --dockerfile dockerfiles/$IMAGE_NAME/Dockerfile
-      --destination $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --destination $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+      --destination docker.io/$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+      --destination docker.io/$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
   
 # # Push to Dockerhub
 # .push_to_docker_hub:               &push_to_docker_hub

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,34 +12,51 @@ variables:                         &default-vars
   DOCKER_HOST:                     tcp://localhost:2375
   DOCKER_DRIVER:                   overlay2
   IMAGE_TAG:                       latest
-  REGISTRY_PATH:                   paritytech
+  REGISTRY_PATH:                   docker.io/paritytech
 
 default:
   cache:                           {}
 
 .build:                            &docker_build
   stage:                           build
-  image:
-    name: gcr.io/kaniko-project/executor:debug
-    entrypoint: [""]
+  image:                           quay.io/buildah/stable
+    # name: gcr.io/kaniko-project/executor:debug
+    # entrypoint: [""]
   rules:
     - if: $IMAGE_NAME == $CI_JOB_NAME
   tags:
     - kubernetes-parity-build
 
-# Push to Dockerhub
+# Push to Dockerhub using buildah
 .push_to_docker_hub:               &push_to_docker_hub
   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-  - mkdir -p /kaniko/.docker
-  - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"$DOCKER_USER\",\"password\":\"$DOCKER_PASSWORD\"}}}" > /kaniko/.docker/config.json
-  - /kaniko/executor
+  - buildah version
+  - buildah bud --no-cache
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH=$REGISTRY_PATH
-      --context dockerfiles
-      --dockerfile dockerfiles/$IMAGE_NAME/Dockerfile
-      --destination=docker.io/$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --destination=docker.io/$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+      --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
+  - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+  - buildah push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+  - buildah push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+  - buildah logout
+
+
+# # Push to Dockerhub using kaniko
+# .push_to_docker_hub:               &push_to_docker_hub
+#   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
+#   - mkdir -p /kaniko/.docker
+#   - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"$DOCKER_USER\",\"password\":\"$DOCKER_PASSWORD\"}}}" > /kaniko/.docker/config.json
+#   - /kaniko/executor
+#       --build-arg VCS_REF="$CI_COMMIT_SHA"
+#       --build-arg BUILD_DATE="$(date +%Y%m%d)"
+#       --build-arg REGISTRY_PATH=$REGISTRY_PATH
+#       --context dockerfiles
+#       --dockerfile dockerfiles/$IMAGE_NAME/Dockerfile
+#       --destination=$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+#       --destination=$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
   
 # # Push to Dockerhub
 # .push_to_docker_hub:               &push_to_docker_hub
@@ -56,6 +73,8 @@ default:
 #   - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
 #   - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
 #   - docker logout
+
+
 
 .push_to_staging:                  &push_to_staging
   - docker build
@@ -82,7 +101,7 @@ default:
 
 #### stage:                        build
 
-#Build and push to docker hub and CI registry
+#Build and push to docker hub
 base-ci-linux:
   <<:                              *docker_build
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -242,6 +242,7 @@ container_scanning:
     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$IMAGE_NAME
     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
     DOCKERFILE_PATH:               dockerfiles/$IMAGE_NAME/Dockerfile
+    REGISTRY_INSECURE:             "true"
   rules:
     - if: $IMAGE_NAME
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,6 @@ default:
 .build:                            &docker_build
   stage:                           build
   image:                           quay.io/buildah/stable
-    # name: gcr.io/kaniko-project/executor:debug
-    # entrypoint: [""]
   rules:
     - if: $IMAGE_NAME == $CI_JOB_NAME
   tags:
@@ -31,7 +29,8 @@ default:
 .push_to_docker_hub:               &push_to_docker_hub
   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
   - buildah version
-  - buildah bud --no-cache
+  - buildah bud
+      --squash
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
@@ -40,41 +39,8 @@ default:
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
   - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
   - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
-  - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+                 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
   - buildah logout "$REGISTRY_PATH"
-
-
-# # Push to Dockerhub using kaniko
-# .push_to_docker_hub:               &push_to_docker_hub
-#   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-#   - mkdir -p /kaniko/.docker
-#   - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"username\":\"$DOCKER_USER\",\"password\":\"$DOCKER_PASSWORD\"}}}" > /kaniko/.docker/config.json
-#   - /kaniko/executor
-#       --build-arg VCS_REF="$CI_COMMIT_SHA"
-#       --build-arg BUILD_DATE="$(date +%Y%m%d)"
-#       --build-arg REGISTRY_PATH=$REGISTRY_PATH
-#       --context dockerfiles
-#       --dockerfile dockerfiles/$IMAGE_NAME/Dockerfile
-#       --destination=$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-#       --destination=$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-  
-# # Push to Dockerhub
-# .push_to_docker_hub:               &push_to_docker_hub
-#   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-#   - docker build --no-cache
-#       --build-arg VCS_REF="$CI_COMMIT_SHA"
-#       --build-arg BUILD_DATE="$(date +%Y%m%d)"
-#       --build-arg REGISTRY_PATH=$REGISTRY_PATH
-#       --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-#       --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-#       --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
-#   - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-#   - docker info
-#   - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-#   - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-#   - docker logout
-
-
 
 .push_to_staging:                  &push_to_staging
   - docker build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,9 +19,9 @@ default:
 
 .build:                            &docker_build
   stage:                           build
-  image:                           docker:dind-rootless
-  services:
-    - docker:dind
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [""]
   rules:
     - if: $IMAGE_NAME == $CI_JOB_NAME
   tags:
@@ -30,18 +30,33 @@ default:
 # Push to Dockerhub
 .push_to_docker_hub:               &push_to_docker_hub
   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-  - docker build --no-cache
+  - mkdir -p /kaniko/.docker
+  - echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\":\"$(echo -n \"$DOCKER_USER\":\"$DOCKER_PASSWORD\" | base64)\"}}}" > /kaniko/.docker/config.json
+  - /kaniko/executor
+      --cache=true
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH=$REGISTRY_PATH
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
-  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-  - docker info
-  - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-  - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-  - docker logout
+      --context dockerfiles
+      --dockerfile dockerfiles/$IMAGE_NAME/Dockerfile
+      --destination $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+      --destination $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+  
+# # Push to Dockerhub
+# .push_to_docker_hub:               &push_to_docker_hub
+#   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
+#   - docker build --no-cache
+#       --build-arg VCS_REF="$CI_COMMIT_SHA"
+#       --build-arg BUILD_DATE="$(date +%Y%m%d)"
+#       --build-arg REGISTRY_PATH=$REGISTRY_PATH
+#       --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+#       --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+#       --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
+#   - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
+#   - docker info
+#   - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
+#   - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+#   - docker logout
 
 .push_to_staging:                  &push_to_staging
   - docker build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,6 @@ stages:
   - prod
 
 variables:                         &default-vars
-  # DOCKER_HOST:                     tcp://docker:2375
-  DOCKER_HOST:                     tcp://localhost:2375
-  STORAGE_DRIVER:                  overlay2
   IMAGE_TAG:                       latest
   REGISTRY_PATH:                   docker.io/paritytech
 
@@ -37,37 +34,39 @@ default:
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
+  - buildah info
   - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
   - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
                  "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
   - buildah logout "$REGISTRY_PATH"
 
 .push_to_staging:                  &push_to_staging
-  - docker build
-        --build-arg VCS_REF="$CI_COMMIT_SHA"
-        --build-arg BUILD_DATE="$(date +%Y%m%d)"
-        --build-arg REGISTRY_PATH=$REGISTRY_PATH
-        --tag $REGISTRY_PATH/$IMAGE_NAME:staging
-        --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
-  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-  - docker info
-  - docker push $REGISTRY_PATH/$IMAGE_NAME:staging
-  - docker logout
+  - buildah build
+      --squash
+      --build-arg VCS_REF="$CI_COMMIT_SHA"
+      --build-arg BUILD_DATE="$(date +%Y%m%d)"
+      --build-arg REGISTRY_PATH="$REGISTRY_PATH"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:staging"
+      --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
+  - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+  - buildah info
+  - buildah push "$REGISTRY_PATH/$IMAGE_NAME:staging"
+  - buildah logout "$REGISTRY_PATH"
 
 .push_to_production:               &push_to_production
   - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-  - docker info
-  - docker pull $REGISTRY_PATH/$IMAGE_NAME:staging
-  - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:production
-  - docker tag $REGISTRY_PATH/$IMAGE_NAME:staging $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-  - docker push $REGISTRY_PATH/$IMAGE_NAME:production
-  - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG
-  - docker logout
+  - buildah pull "$REGISTRY_PATH/$IMAGE_NAME:staging"
+  - buildah tag "$REGISTRY_PATH/$IMAGE_NAME:staging" "$REGISTRY_PATH/$IMAGE_NAME:production"
+  - buildah tag "$REGISTRY_PATH/$IMAGE_NAME:staging" "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+  - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+  - buildah info
+  - buildah push "$REGISTRY_PATH/$IMAGE_NAME:production"
+                "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+  - buildah logout "$REGISTRY_PATH"
 
 #### stage:                        build
 
-#Build and push to docker hub
+# Build and push to docker hub
 base-ci-linux:
   <<:                              *docker_build
   script:
@@ -129,18 +128,19 @@ chaostools:
       | KUBE_VERSION = $BUILD_KUBE_VERSION
       |
       EOT
-    - docker build
+    - buildah bud
+      --squash
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-      --build-arg REGISTRY_PATH=$REGISTRY_PATH
+      --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --build-arg KUBE_VERSION="$BUILD_KUBE_VERSION"
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+      --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
-    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-    - docker info
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-    - docker logout
+    - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+    - buildah info
+    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+    - buildah logout "$REGISTRY_PATH"
 
 # special case as version tags are introduced
 kubetools:
@@ -163,21 +163,22 @@ kubetools:
       | HELM_VERSION = $BUILD_HELM_VERSION
       |
       EOT
-    - docker build
+    - buildah bud
+      --squash
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-      --build-arg REGISTRY_PATH=$REGISTRY_PATH
+      --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --build-arg KUBE_VERSION="$BUILD_KUBE_VERSION"
       --build-arg HELM_VERSION="$BUILD_HELM_VERSION"
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION
-      --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION"
+      --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
-    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-    - docker info
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION
-    - docker logout
+    - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+    - buildah info
+    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION"
+    - buildah logout "$REGISTRY_PATH"
 
 
 terraform:
@@ -195,20 +196,20 @@ terraform:
       | TERRAFORM_VERSION = $TERRAFORM_VERSION
       |
       EOT
-    - docker build
+    - buildah bud
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-      --build-arg REGISTRY_PATH=$REGISTRY_PATH
+      --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --build-arg TERRAFORM_VERSION="$TERRAFORM_VERSION"
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-      --tag $REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION
-      --file dockerfiles/$IMAGE_NAME/Dockerfile dockerfiles
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
+      --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
-    - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-    - docker info
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-    - docker push $REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION
-    - docker logout
+    - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+    - buildah info
+    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
+    - buildah logout "$REGISTRY_PATH"
 
 #### stage:                        test
 
@@ -313,9 +314,7 @@ sccache-ci-ubuntu-test:
 
 ci-linux-production:
   stage:                           prod
-  image:                           docker:stable
-  services:
-    - docker:dind
+  image:                           quay.io/buildah/stable
   rules:
     - if: $IMAGE_NAME == "ci-linux"
   script:
@@ -325,9 +324,7 @@ ci-linux-production:
 
 ink-ci-linux-production:           &push-after-triggered-pipeline
   stage:                           prod
-  image:                           docker:stable
-  services:
-    - docker:dind
+  image:                           quay.io/buildah/stable
   needs:
     - job:                         ink-ci-linux-test
       artifacts:                   false

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
 variables:                         &default-vars
   # DOCKER_HOST:                     tcp://docker:2375
   DOCKER_HOST:                     tcp://localhost:2375
-  DOCKER_DRIVER:                   overlay2
+  STORAGE_DRIVER:                   vfs
   IMAGE_TAG:                       latest
   REGISTRY_PATH:                   docker.io/paritytech
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,8 +37,8 @@ default:
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
   - buildah info
   - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
-  - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
-                 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+  - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+                               "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
   - buildah logout "$REGISTRY_PATH"
 
 .push_to_staging:                  &push_to_staging

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,8 +42,9 @@ default:
   - buildah logout "$REGISTRY_PATH"
 
 .push_to_staging:                  &push_to_staging
-  - buildah build
+  - buildah bud
       --squash
+      --format=docker
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
@@ -51,7 +52,7 @@ default:
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
   - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
   - buildah info
-  - buildah push "$REGISTRY_PATH/$IMAGE_NAME:staging"
+  - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:staging"
   - buildah logout "$REGISTRY_PATH"
 
 .push_to_production:               &push_to_production
@@ -61,8 +62,8 @@ default:
   - buildah tag "$REGISTRY_PATH/$IMAGE_NAME:staging" "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
   - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
   - buildah info
-  - buildah push "$REGISTRY_PATH/$IMAGE_NAME:production"
-                "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+  - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:production"
+                               "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
   - buildah logout "$REGISTRY_PATH"
 
 #### stage:                        build
@@ -131,6 +132,7 @@ chaostools:
       EOT
     - buildah bud
       --squash
+      --format=docker
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
@@ -140,7 +142,7 @@ chaostools:
     # Push to Dockerhub
     - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
     - buildah info
-    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
     - buildah logout "$REGISTRY_PATH"
 
 # special case as version tags are introduced
@@ -166,6 +168,7 @@ kubetools:
       EOT
     - buildah bud
       --squash
+      --format=docker
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
@@ -177,8 +180,8 @@ kubetools:
     # Push to Dockerhub
     - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
     - buildah info
-    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
-    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+                                 "$REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION"
     - buildah logout "$REGISTRY_PATH"
 
 
@@ -198,6 +201,8 @@ terraform:
       |
       EOT
     - buildah bud
+      --squash
+      --format=docker
       --build-arg VCS_REF="$CI_COMMIT_SHA"
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
@@ -208,8 +213,8 @@ terraform:
     # Push to Dockerhub
     - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
     - buildah info
-    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
-    - buildah push "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+                                 "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
     - buildah logout "$REGISTRY_PATH"
 
 #### stage:                        test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,8 @@ default:
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
   - buildah info
-  - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+  - echo "$DOCKER_PASSWORD" |
+      buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
   - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
                                "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
   - buildah logout "$REGISTRY_PATH"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,8 @@ default:
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --tag "$REGISTRY_PATH/$IMAGE_NAME:staging"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
-  - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+  - echo "$DOCKER_PASSWORD" |
+      buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
   - buildah info
   - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:staging"
   - buildah logout "$REGISTRY_PATH"
@@ -61,7 +62,8 @@ default:
   - buildah pull "$REGISTRY_PATH/$IMAGE_NAME:staging"
   - buildah tag "$REGISTRY_PATH/$IMAGE_NAME:staging" "$REGISTRY_PATH/$IMAGE_NAME:production"
   - buildah tag "$REGISTRY_PATH/$IMAGE_NAME:staging" "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
-  - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+  - echo "$DOCKER_PASSWORD" |
+      buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
   - buildah info
   - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:production"
                                "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
@@ -141,7 +143,8 @@ chaostools:
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
-    - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+    - echo "$DOCKER_PASSWORD" |
+        buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
     - buildah info
     - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
     - buildah logout "$REGISTRY_PATH"
@@ -179,7 +182,8 @@ kubetools:
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
-    - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+    - echo "$DOCKER_PASSWORD" |
+        buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
     - buildah info
     - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
                                  "$REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION"
@@ -212,7 +216,8 @@ terraform:
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
-    - buildah login --username "$DOCKER_USER" --password "$DOCKER_PASSWORD" "$REGISTRY_PATH"
+    - echo "$DOCKER_PASSWORD" |
+        buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
     - buildah info
     - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
                                  "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
 variables:                         &default-vars
   # DOCKER_HOST:                     tcp://docker:2375
   DOCKER_HOST:                     tcp://localhost:2375
-  STORAGE_DRIVER:                   vfs
+  STORAGE_DRIVER:                  overlay2
   IMAGE_TAG:                       latest
   REGISTRY_PATH:                   docker.io/paritytech
 


### PR DESCRIPTION
Recent docker changes have broken our images building. Docker breaks pretty much things lately, so I decided to stay away from it.

First I tried with `kaniko`, and it works well, but decided to move to `buildah` since they are closer to what we do.
The downside is I've broken the [image scanning](https://github.com/optiopay/klar/issues/140), this is something connected with `buildah`'s image manifest version and format.

I'll describe the important changes, because right now all the GitLab CI jobs, those building images are not working. So please take care of your repositories:

- variables starting with `DOCKER*`, such as `DOCKER_HOST`, `DOCKER_DRIVER` are no longer needed, but login creds to dockerhub are certainly needed
- `buildah` uses more transports than `docker`, it means that with the former, we should use full image names, i.e. instead of `paritytech/tools:latest` -> `docker.io/paritytech/tools:latest`
- `docker` -> `buildah` and notice we use ` quay.io/buildah/stable` as the builder image instead of `docker:stable` AND `services: docker:dind`
- please use `--format=docker` after `bud` and `--format=v2s2` after `push`, this is to mitigate the manifest issue with kubernetes that [didn't buy](https://gitlab.parity.io/parity/polkadot/-/jobs/749477) our new images manifests
  the error was
  ```
  ERROR: Job failed (system failure): prepare environment: image pull failed: rpc error: code = Unknown desc = Error response from daemon: mediaType in manifest should be 'application/vnd.docker.distribution.manifest.v2+json' not ''. Check https://docs.gitlab.com/runner/shells/index.html#shell-profile-loading for more information
  ```
- add registry URL (`docker.io` or `docker.io/paritytech`) when you `buildah login` and `buildah logout`
  
Everything else is similar to the docker manner to build images, flags are similar.