### PR TITLE
trivy container scanner v1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -263,11 +263,12 @@ container_scanning:
     # Build report
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress 
         --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    # debug
+    - cat gl-container-scanning-report.json
     # Print report
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
     # Fail on high and critical vulnerabilities
     - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
-    - cat gl-container-scanning-report.json
   cache:
     paths:
       - .trivycache/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -268,7 +268,7 @@ container_scanning:
     - ls /
     - find / -name "gl-container-scanning-report.json"
     # debug
-    - cat gl-container-scanning-report.json
+    - cat "$CI_PROJECT_DIR/gl-container-scanning-report.json"
     # Print report
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
     # Fail on high and critical vulnerabilities

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,6 +256,7 @@ terraform:
 container_scanning:
   image:                           docker.io/aquasec/trivy:latest
   script:
+    - cd /
     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
     - time trivy image --clear-cache
     # update vulnerabilities db

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -266,11 +266,11 @@ container_scanning:
     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
     - trivy image --clear-cache
     # Build report
-    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_NAME
+    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
     # Print report
-    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_NAME
+    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH "$REGISTRY_PATH/$IMAGE_NAME"
     # Fail on high and critical vulnerabilities
-    - trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_NAME
+    - trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
   cache:
     paths:
       - .trivycache/
@@ -303,11 +303,11 @@ container_scanning:
 #   allow_failure: true
 #   script:
 #     # Build report
-#     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_NAME
+#     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
 #     # Print report
-#     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_NAME
+#     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH "$REGISTRY_PATH/$IMAGE_NAME"
 #     # Fail on high and critical vulnerabilities
-#     - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_NAME
+#     - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
 #   cache:
 #     paths:
 #       - .trivycache/
@@ -324,7 +324,7 @@ container_scanning:
 # upside is it uses images from the docker cache
 # container_scanning3:
 #   stage:                           test
-#   image:                           $IMAGE_NAME # check if can be tagged
+#   image:                           $REGISTRY_PATH/$IMAGE_NAME # check if can be tagged
 #   allow_failure:                   true
 #   before_script:
 #     - export LOCAL_TRIVY=$(/ci-cache/trivy/trivy --version | grep -Po "(?<=^Version:).*") || (

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -227,36 +227,140 @@ terraform:
 
 # triggers on $IMAGE_NAME
 # in order to be scanned, EVERY docker build HAS to have $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
+# container_scanning:
+#   # Template does not work, had to override its config from
+#   # https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml
+#   # these settings are from the template 
+#   stage:                           test
+#   image:                           $SECURE_ANALYZERS_PREFIX/klar:$CS_MAJOR_VERSION
+#   services:
+#     - name:                        $CLAIR_DB_IMAGE
+#       alias:                       clair-vulnerabilities-db
+#   allow_failure:                   true
+#   script:
+#     - /analyzer run
+#   artifacts:
+#     reports:
+#       container_scanning:          gl-container-scanning-report.json
+#   variables:
+#     SECURE_ANALYZERS_PREFIX:       "registry.gitlab.com/gitlab-org/security-products/analyzers"
+#     CS_MAJOR_VERSION:              2
+#     CLAIR_DB_IMAGE_TAG:            "latest"
+#     CLAIR_DB_IMAGE:                "$SECURE_ANALYZERS_PREFIX/clair-vulnerabilities-db:$CLAIR_DB_IMAGE_TAG"
+#   # these are our overrides
+#     <<:                            *default-vars
+#     GIT_STRATEGY:                  fetch
+#     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$IMAGE_NAME
+#     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
+#     DOCKERFILE_PATH:               dockerfiles/$IMAGE_NAME/Dockerfile
+#   rules:
+#     - if: $IMAGE_NAME
+#   tags:
+#     - kubernetes-parity-build
+
 container_scanning:
-  # Template does not work, had to override its config from
-  # https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml
-  # these settings are from the template 
-  stage:                           test
-  image:                           $SECURE_ANALYZERS_PREFIX/klar:$CS_MAJOR_VERSION
-  services:
-    - name:                        $CLAIR_DB_IMAGE
-      alias:                       clair-vulnerabilities-db
+  image:                           docker.io/aquasec/trivy:latest
   allow_failure:                   true
   script:
-    - /analyzer run
+    - /ci-cache/trivy/trivy --download-db-only --cache-dir /ci-cache/trivy/cache
+    # cache cleanup is needed when scanning images with the same tags, it does not remove the database
+    - /ci-cache/trivy/trivy image --clear-cache
+    # Build report
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_NAME
+    # Print report
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_NAME
+    # Fail on high and critical vulnerabilities
+    - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_NAME
+  cache:
+    paths:
+      - .trivycache/
   artifacts:
     reports:
-      container_scanning:          gl-container-scanning-report.json
-  variables:
-    SECURE_ANALYZERS_PREFIX:       "registry.gitlab.com/gitlab-org/security-products/analyzers"
-    CS_MAJOR_VERSION:              2
-    CLAIR_DB_IMAGE_TAG:            "latest"
-    CLAIR_DB_IMAGE:                "$SECURE_ANALYZERS_PREFIX/clair-vulnerabilities-db:$CLAIR_DB_IMAGE_TAG"
-  # these are our overrides
-    <<:                            *default-vars
-    GIT_STRATEGY:                  fetch
-    CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$IMAGE_NAME
-    CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
-    DOCKERFILE_PATH:               dockerfiles/$IMAGE_NAME/Dockerfile
+      container_scanning: gl-container-scanning-report.json
   rules:
     - if: $IMAGE_NAME
   tags:
     - kubernetes-parity-build
+  
+
+# official job suggested in trivy doc
+# container_scanning2:
+#   stage: test
+#   image: docker:stable
+#   services:
+#     - name: docker:dind
+#       entrypoint: ["env", "-u", "DOCKER_HOST"]
+#       command: ["dockerd-entrypoint.sh"]
+#   variables:
+#     DOCKER_HOST: tcp://docker:2375/
+#     DOCKER_DRIVER: overlay2
+#     # See https://github.com/docker-library/docker/pull/166
+#     DOCKER_TLS_CERTDIR: ""
+#   before_script:
+#     - export TRIVY_VERSION=$(wget -qO - "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+#     - echo $TRIVY_VERSION
+#     - wget --no-verbose https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -O - | tar -zxvf -
+#   allow_failure: true
+#   script:
+#     # Build report
+#     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_NAME
+#     # Print report
+#     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_NAME
+#     # Fail on high and critical vulnerabilities
+#     - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_NAME
+#   cache:
+#     paths:
+#       - .trivycache/
+#   artifacts:
+#     reports:
+#       container_scanning: gl-container-scanning-report.json
+#   rules:
+#     - if: $IMAGE_NAME
+#   tags:
+#     - kubernetes-parity-build
+
+# concept of using trivy as a binary, updating and running in the $IMAGE_NAME
+# downside is it uses tar and curl and we'd like to get rid of them in some images
+# upside is it uses images from the docker cache
+# container_scanning3:
+#   stage:                           test
+#   image:                           $IMAGE_NAME # check if can be tagged
+#   allow_failure:                   true
+#   before_script:
+#     - export LOCAL_TRIVY=$(/ci-cache/trivy/trivy --version | grep -Po "(?<=^Version:).*") || (
+#         echo "No local trivy, downloading."
+#       )
+#     - export LATEST_TRIVY=$(
+#         curl -sS "https://api.github.com/repos/aquasecurity/trivy/releases/latest" |
+#         grep '"tag_name":' |
+#         sed -E 's/.*"v([^"]+)".*/\1/'
+#       )
+#     - mkdir -p /ci-cache/trivy/cache
+#     # compares local vs latest version, updates if newer
+#     - if [ $LOCAL_TRIVY != $LATEST_TRIVY ]; then
+#         curl -sS -L "https://github.com/aquasecurity/trivy/releases/download/v${LATEST_TRIVY}/trivy_${LATEST_TRIVY}_Linux-64bit.tar.gz"
+#           --output /tmp/trivy.tar.gz;
+#         cd /tmp;
+#         tar -xzf trivy.tar.gz trivy;
+#         mv trivy /ci-cache/trivy/;
+#       fi
+#   script:
+#     - /ci-cache/trivy/trivy --download-db-only --cache-dir /ci-cache/trivy/cache
+#     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
+#     - /ci-cache/trivy/trivy image --clear-cache
+#     # Build report
+#     - /ci-cache/trivy/trivy --exit-code 0 --cache-dir /ci-cache/trivy/cache --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json filesystem /
+#     # Print report
+#     - /ci-cache/trivy/trivy --exit-code 0 --cache-dir /ci-cache/trivy/cache --no-progress --severity HIGH filesystem /
+#     # Fail on high and critical vulnerabilities
+#     - /ci-cache/trivy/trivy --exit-code 1 --cache-dir /ci-cache/trivy/cache --severity CRITICAL --no-progress filesystem /
+#   artifacts:
+#     reports:
+#       container_scanning: gl-container-scanning-report.json
+#   rules:
+#     - if: $IMAGE_NAME
+#   tags:
+#     - linux-docker
 
 ci-linux-test:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,13 +262,8 @@ container_scanning:
     # update vulnerabilities db
     - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # Build report
-    # - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
-    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" --output "$CI_PROJECT_DIR/gl-container-scanning-report.json" "$REGISTRY_PATH/$IMAGE_NAME"
-    - pwd
-    - ls /
-    - find / -name "gl-container-scanning-report.json"
-    # debug
-    - cat "$CI_PROJECT_DIR/gl-container-scanning-report.json"
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl"
+        --output "$CI_PROJECT_DIR/gl-container-scanning-report.json" "$REGISTRY_PATH/$IMAGE_NAME"
     # Print report
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
     # Fail on high and critical vulnerabilities
@@ -277,6 +272,7 @@ container_scanning:
     paths:
       - .trivycache/
   artifacts:
+    when:                          always
     reports:
       # there's something with this template
       container_scanning:          gl-container-scanning-report.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -260,25 +260,26 @@ terraform:
 
 container_scanning:
   image:                           docker.io/aquasec/trivy:latest
-  allow_failure:                   true
   script:
-    - trivy --download-db-only --no-progress --cache-dir /ci-cache/trivy/cache
+    - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
-    - trivy image --clear-cache
+    - time trivy image --clear-cache
     # Build report
-    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress 
+        --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
     # Print report
-    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH "$REGISTRY_PATH/$IMAGE_NAME"
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
     # Fail on high and critical vulnerabilities
-    - trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
+    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
   cache:
     paths:
       - .trivycache/
   artifacts:
     reports:
-      container_scanning: gl-container-scanning-report.json
+      container_scanning:          gl-container-scanning-report.json
   rules:
     - if: $IMAGE_NAME
+  allow_failure:                   true
   tags:
     - kubernetes-parity-build
   

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,15 +262,15 @@ container_scanning:
   image:                           docker.io/aquasec/trivy:latest
   allow_failure:                   true
   script:
-    - /ci-cache/trivy/trivy --download-db-only --cache-dir /ci-cache/trivy/cache
+    - trivy --download-db-only --cache-dir /ci-cache/trivy/cache
     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
-    - /ci-cache/trivy/trivy image --clear-cache
+    - trivy image --clear-cache
     # Build report
-    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_NAME
+    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_NAME
     # Print report
-    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_NAME
+    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_NAME
     # Fail on high and critical vulnerabilities
-    - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_NAME
+    - trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_NAME
   cache:
     paths:
       - .trivycache/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,11 +262,11 @@ container_scanning:
   image:                           docker.io/aquasec/trivy:latest
   allow_failure:                   true
   script:
-    - trivy --download-db-only --cache-dir /ci-cache/trivy/cache
+    - trivy --download-db-only --no-progress --cache-dir /ci-cache/trivy/cache
     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
     - trivy image --clear-cache
     # Build report
-    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
     # Print report
     - trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH "$REGISTRY_PATH/$IMAGE_NAME"
     # Fail on high and critical vulnerabilities

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -261,8 +261,8 @@ container_scanning:
     # update vulnerabilities db
     - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # Build report
-    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress 
-        --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    # - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" --output gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
     # debug
     - cat gl-container-scanning-report.json
     # Print report

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,7 +278,7 @@ container_scanning:
   artifacts:
     reports:
       # there's something with this template
-      container_scanning:          gl-container-scanning-report.json
+      container_scanning:          /gl-container-scanning-report.json
   rules:
     - if: $IMAGE_NAME
   allow_failure:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -263,7 +263,7 @@ container_scanning:
     - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # Build report
     # - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
-    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" --output gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" --output "$CI_PROJECT_DIR/gl-container-scanning-report.json" "$REGISTRY_PATH/$IMAGE_NAME"
     - pwd
     - ls /
     - find / -name "gl-container-scanning-report.json"
@@ -279,7 +279,7 @@ container_scanning:
   artifacts:
     reports:
       # there's something with this template
-      container_scanning:          /gl-container-scanning-report.json
+      container_scanning:          gl-container-scanning-report.json
   rules:
     - if: $IMAGE_NAME
   allow_failure:                   true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -271,6 +271,7 @@ container_scanning:
       - .trivycache/
   artifacts:
     reports:
+      # there's something with this template
       container_scanning:          gl-container-scanning-report.json
   rules:
     - if: $IMAGE_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -263,9 +263,10 @@ container_scanning:
     - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # Build report
     # - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" --output gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
     - pwd
     - ls /
-    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" --output gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    - find / -name "gl-container-scanning-report.json"
     # debug
     - cat gl-container-scanning-report.json
     # Print report

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,6 @@ stages:
   - prod
 
 variables:                         &default-vars
-  IMAGE_TAG:                       latest
   REGISTRY_PATH:                   docker.io/paritytech
 
 default:
@@ -32,13 +31,13 @@ default:
       --build-arg BUILD_DATE="$(date +%Y%m%d)"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
-      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
   - buildah info
   - echo "$DOCKER_PASSWORD" |
       buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
   - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
-  - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+  - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:latest"
   - buildah logout "$REGISTRY_PATH"
 
 .push_to_staging:                  &push_to_staging
@@ -137,13 +136,13 @@ chaostools:
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --build-arg KUBE_VERSION="$BUILD_KUBE_VERSION"
-      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
     - echo "$DOCKER_PASSWORD" |
         buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
     - buildah info
-    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:latest"
     - buildah logout "$REGISTRY_PATH"
 
 # special case as version tags are introduced
@@ -174,14 +173,14 @@ kubetools:
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --build-arg KUBE_VERSION="$BUILD_KUBE_VERSION"
       --build-arg HELM_VERSION="$BUILD_HELM_VERSION"
-      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
     - echo "$DOCKER_PASSWORD" |
         buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
     - buildah info
-    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:latest"
     - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$BUILD_HELM_VERSION"
     - buildah logout "$REGISTRY_PATH"
 
@@ -207,54 +206,23 @@ terraform:
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --build-arg TERRAFORM_VERSION="$TERRAFORM_VERSION"
-      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     # Push to Dockerhub
     - echo "$DOCKER_PASSWORD" |
         buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
     - buildah info
-    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:latest"
     - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
     - buildah logout "$REGISTRY_PATH"
 
 #### stage:                        test
 
-# triggers on $IMAGE_NAME
-# in order to be scanned, EVERY docker build HAS to have $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
-# container_scanning:
-#   # Template does not work, had to override its config from
-#   # https://gitlab.com/gitlab-org/gitlab/blob/master/lib/gitlab/ci/templates/Security/Container-Scanning.gitlab-ci.yml
-#   # these settings are from the template 
-#   stage:                           test
-#   image:                           $SECURE_ANALYZERS_PREFIX/klar:$CS_MAJOR_VERSION
-#   services:
-#     - name:                        $CLAIR_DB_IMAGE
-#       alias:                       clair-vulnerabilities-db
-#   allow_failure:                   true
-#   script:
-#     - /analyzer run
-#   artifacts:
-#     reports:
-#       container_scanning:          gl-container-scanning-report.json
-#   variables:
-#     SECURE_ANALYZERS_PREFIX:       "registry.gitlab.com/gitlab-org/security-products/analyzers"
-#     CS_MAJOR_VERSION:              2
-#     CLAIR_DB_IMAGE_TAG:            "latest"
-#     CLAIR_DB_IMAGE:                "$SECURE_ANALYZERS_PREFIX/clair-vulnerabilities-db:$CLAIR_DB_IMAGE_TAG"
-#   # these are our overrides
-#     <<:                            *default-vars
-#     GIT_STRATEGY:                  fetch
-#     CI_APPLICATION_REPOSITORY:     $REGISTRY_PATH/$IMAGE_NAME
-#     CI_APPLICATION_TAG:            $IMAGE_TAG # OR $IMAGE_DATE_TAG
-#     DOCKERFILE_PATH:               dockerfiles/$IMAGE_NAME/Dockerfile
-#   rules:
-#     - if: $IMAGE_NAME
-#   tags:
-#     - kubernetes-parity-build
-
 container_scanning:
   image:                           docker.io/aquasec/trivy:latest
+  variables:
+    FULL_IMAGE_NAME:               $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG
   script:
     - cd /
     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
@@ -263,104 +231,26 @@ container_scanning:
     - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # Build report
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl"
-        --output "$CI_PROJECT_DIR/gl-container-scanning-report.json" "$REGISTRY_PATH/$IMAGE_NAME"
+        --output "$CI_PROJECT_DIR/gl-container-scanning-report.json" "$FULL_IMAGE_NAME"
     # Print report
-    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
+    - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$FULL_IMAGE_NAME"
     # Fail on high and critical vulnerabilities
-    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
+    - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$FULL_IMAGE_NAME"
   cache:
+    # TODO: move this cache to k8s volume when it's configured
     paths:
       - .trivycache/
   artifacts:
     when:                          always
     reports:
-      # there's something with this template
       container_scanning:          gl-container-scanning-report.json
   rules:
-    - if: $IMAGE_NAME
+    # $IMAGE_TAG is needed for trivy. Should me mentioned in schedule's variables. I.e. latest, staging, v2.0.0.
+    - if: $IMAGE_NAME && $IMAGE_TAG
+  # TODO: remove when all criticals are solved 
   allow_failure:                   true
   tags:
     - kubernetes-parity-build
-  
-
-# official job suggested in trivy doc
-# container_scanning2:
-#   stage: test
-#   image: docker:stable
-#   services:
-#     - name: docker:dind
-#       entrypoint: ["env", "-u", "DOCKER_HOST"]
-#       command: ["dockerd-entrypoint.sh"]
-#   variables:
-#     DOCKER_HOST: tcp://docker:2375/
-#     DOCKER_DRIVER: overlay2
-#     # See https://github.com/docker-library/docker/pull/166
-#     DOCKER_TLS_CERTDIR: ""
-#   before_script:
-#     - export TRIVY_VERSION=$(wget -qO - "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-#     - echo $TRIVY_VERSION
-#     - wget --no-verbose https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -O - | tar -zxvf -
-#   allow_failure: true
-#   script:
-#     # Build report
-#     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
-#     # Print report
-#     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH "$REGISTRY_PATH/$IMAGE_NAME"
-#     # Fail on high and critical vulnerabilities
-#     - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
-#   cache:
-#     paths:
-#       - .trivycache/
-#   artifacts:
-#     reports:
-#       container_scanning: gl-container-scanning-report.json
-#   rules:
-#     - if: $IMAGE_NAME
-#   tags:
-#     - kubernetes-parity-build
-
-# concept of using trivy as a binary, updating and running in the $IMAGE_NAME
-# downside is it uses tar and curl and we'd like to get rid of them in some images
-# upside is it uses images from the docker cache
-# container_scanning3:
-#   stage:                           test
-#   image:                           $REGISTRY_PATH/$IMAGE_NAME # check if can be tagged
-#   allow_failure:                   true
-#   before_script:
-#     - export LOCAL_TRIVY=$(/ci-cache/trivy/trivy --version | grep -Po "(?<=^Version:).*") || (
-#         echo "No local trivy, downloading."
-#       )
-#     - export LATEST_TRIVY=$(
-#         curl -sS "https://api.github.com/repos/aquasecurity/trivy/releases/latest" |
-#         grep '"tag_name":' |
-#         sed -E 's/.*"v([^"]+)".*/\1/'
-#       )
-#     - mkdir -p /ci-cache/trivy/cache
-#     # compares local vs latest version, updates if newer
-#     - if [ $LOCAL_TRIVY != $LATEST_TRIVY ]; then
-#         curl -sS -L "https://github.com/aquasecurity/trivy/releases/download/v${LATEST_TRIVY}/trivy_${LATEST_TRIVY}_Linux-64bit.tar.gz"
-#           --output /tmp/trivy.tar.gz;
-#         cd /tmp;
-#         tar -xzf trivy.tar.gz trivy;
-#         mv trivy /ci-cache/trivy/;
-#       fi
-#   script:
-#     - /ci-cache/trivy/trivy --download-db-only --cache-dir /ci-cache/trivy/cache
-#     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
-#     - /ci-cache/trivy/trivy image --clear-cache
-#     # Build report
-#     - /ci-cache/trivy/trivy --exit-code 0 --cache-dir /ci-cache/trivy/cache --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json filesystem /
-#     # Print report
-#     - /ci-cache/trivy/trivy --exit-code 0 --cache-dir /ci-cache/trivy/cache --no-progress --severity HIGH filesystem /
-#     # Fail on high and critical vulnerabilities
-#     - /ci-cache/trivy/trivy --exit-code 1 --cache-dir /ci-cache/trivy/cache --severity CRITICAL --no-progress filesystem /
-#   artifacts:
-#     reports:
-#       container_scanning: gl-container-scanning-report.json
-#   rules:
-#     - if: $IMAGE_NAME
-#   tags:
-#     - linux-docker
 
 ci-linux-test:
   stage:                           test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -256,9 +256,10 @@ terraform:
 container_scanning:
   image:                           docker.io/aquasec/trivy:latest
   script:
-    - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
     - time trivy image --clear-cache
+    # update vulnerabilities db
+    - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # Build report
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress 
         --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
@@ -266,6 +267,7 @@ container_scanning:
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
     # Fail on high and critical vulnerabilities
     - time trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress "$REGISTRY_PATH/$IMAGE_NAME"
+    - cat gl-container-scanning-report.json
   cache:
     paths:
       - .trivycache/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -262,6 +262,8 @@ container_scanning:
     - time trivy --download-db-only --no-progress --cache-dir .trivycache/
     # Build report
     # - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "/contrib/gitlab.tpl" -o gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
+    - pwd
+    - ls /
     - time trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" --output gl-container-scanning-report.json "$REGISTRY_PATH/$IMAGE_NAME"
     # debug
     - cat gl-container-scanning-report.json


### PR DESCRIPTION
FYI: new scanning job requires both `IMAGE_NAME` and `IMAGE_TAG` set in [schedule](https://gitlab.parity.io/parity/infrastructure/scripts/-/pipeline_schedules). I've set them for all schedules we have.

Since the official GitLab scanner [fails](https://gitlab.parity.io/parity/infrastructure/scripts/-/jobs/782258#L971) to scan the images we push to dockerhub by buildah and GitLab is knowingly [slow](https://gitlab.com/gitlab-org/gitlab/-/issues/294421#note_472133709) in fixing everything, I've decided to introduce an alternative scanner. 

Did a little research and `trivy` is better than `clar`/`clair`/`klar` and, what's important, **is supported**.

It's also good at checking [various](https://gitlab.com/gitlab-org/gitlab/-/issues/294421#note_472133709) lockfiles, i.e. Rust, node.js, python, etc. (For Rust, however, it uses the same same advisory as `cargo deny` and `cargo audit`). Just may come handy.

cc: https://github.com/paritytech/ci_cd/issues/34 https://github.com/paritytech/ci_cd/issues/90