### PR TITLE
WIP: dockerfile: add llvm-tools-preview

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -39,7 +39,7 @@ RUN	set -eux; \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
-		--profile minimal --component rustfmt clippy miri rust-src; \
+		--profile minimal --component rustfmt clippy miri rust-src llvm-tools-preview; \
 	rustup default nightly; \
 # We require `xargo` so that `miri` runs properly
 # We require `grcov` for coverage reporting and `rust-covfix` to improve it.

--- a/dockerfiles/ink-ci-linux/README.md
+++ b/dockerfiles/ink-ci-linux/README.md
@@ -29,6 +29,7 @@ We always try to use the [latest possible](https://rust-lang.github.io/rustup-co
 - `rust-src`: The Rust sources of the standard library.
 - `miri`: The Rust MIR interpreter that interprets the test suite with additional checks.
 - `rustfmt`: The Rust code formatter.
+- `llvm-tools-preview`: LLVM tools.
 
 **Rust tools & toolchains:**
 


### PR DESCRIPTION
It's necessary for source-based code coverage.

It maybe removes `rust-src`, needs checking if it's needed.

After the source-based code coverage is successful `rust-covfix` is no longer needed.