### PR TITLE
dockerfile: add diener

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -31,6 +31,7 @@ RUN set -eux; \
 	rustup target add wasm32-unknown-unknown --toolchain nightly; \
 # install cargo tools
 	cargo install cargo-audit cargo-web wasm-pack cargo-deny wasm-bindgen-cli; \
+	cargo install --version 0.2.0 diener; \
 # install wasm-gc. It's useful for stripping slimming down wasm binaries (polkadot)
 	cargo +nightly install wasm-gc; \
 # versions


### PR DESCRIPTION
Adds `diener` to the CI image.
Now it needs to be removed from https://github.com/paritytech/substrate/blob/3c531e291fcc2c315abd3dcf436c487cdd91bd25/.maintain/gitlab/check_polkadot_companion_build.sh#L44