### PR TITLE
CI: trigger substrate CI on image test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -259,34 +259,17 @@ container_scanning:
 
 ci-linux-test:
   stage:                           test
-  image:                           $REGISTRY_PATH/$IMAGE_NAME:staging
-  interruptible:                   true
+  variables:
+    CI_IMAGE:                      "paritytech/ci-linux:staging"
+    # this is to rewrite "-Dwarnings" we use in Substrate CI since new warnings
+    # are often introduced and we do not want to fail on them in this case
+    RUSTFLAGS:                     "-Cdebug-assertions=y"
   rules:
     - if: $IMAGE_NAME == "ci-linux"
-  variables:
-    <<:                            *default-vars
-    GIT_STRATEGY:                  none
-    RUSTFLAGS:                     "-Cdebug-assertions=y"
-    WASM_BUILD_NO_COLOR:           1
-  before_script:
-    - rustup show
-    - cargo --version
-    - sccache -s
-  script:
-    - git clone https://github.com/paritytech/substrate .
-    # test-linux-stable:
-    - time cargo test --workspace --locked --release --verbose --features runtime-benchmarks --manifest-path bin/node/cli/Cargo.toml
-    # check-web-wasm:
-    - time cargo build --target=wasm32-unknown-unknown -p sp-io
-    - time cargo build --target=wasm32-unknown-unknown -p sp-runtime
-    - time cargo build --target=wasm32-unknown-unknown -p sp-std
-    - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-aura
-    - time cargo build --target=wasm32-unknown-unknown -p sc-consensus-babe
-    - time cargo build --target=wasm32-unknown-unknown -p sp-consensus
-    - time cargo build --target=wasm32-unknown-unknown -p sc-telemetry
-    - time cargo +nightly build --manifest-path=bin/node/cli/Cargo.toml --no-default-features --features browser --target=wasm32-unknown-unknown -Z features=itarget
-  tags:
-    - linux-docker
+  trigger:
+    project:                       parity/substrate
+    branch:                        master
+    strategy:                      depend
 
 ink-ci-linux-test:
   stage:                           test


### PR DESCRIPTION
For the better maintainability and observability it's good to trigger the repo itself, so developers will know what stops the CI image from being updated.

Overrides `RUSTFLAGS` to avoid failures on `-Dwarnings`, in this case it's not needed.

Merge after `CI_IMAGE` is introduced to substrate CI repo.