### PR TITLE
dockerfiles: restore cargo-deny as it's fixed, add mdbook

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -30,11 +30,8 @@ RUN set -eux && \
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
 # install cargo tools
-	cargo install cargo-audit cargo-web wasm-pack wasm-bindgen-cli && \
+	cargo install cargo-audit cargo-web wasm-pack wasm-bindgen-cli cargo-deny mdbook && \
 	cargo install --version 0.3.1 diener && \
-	# FIXME: temporarily workaround to install cargo-deny
-	# https://github.com/EmbarkStudios/cargo-deny/issues/331#issuecomment-778617026
-	install cargo-deny --locked && \
 # install wasm-gc. It's useful for stripping slimming down wasm binaries (polkadot)
 	cargo +nightly install wasm-gc && \
 # versions

--- a/dockerfiles/ci-linux/README.md
+++ b/dockerfiles/ci-linux/README.md
@@ -36,6 +36,7 @@ Used to build and test Substrate-based projects.
 - `wasm-pack`
 - `wasm-bindgen`
 - `cargo-deny`
+- `mdbook`
 - `wasm32-unknown-unknown` toolchain
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/ci-linux) for the registry.
@@ -45,7 +46,7 @@ Used to build and test Substrate-based projects.
 ```yaml
 test-substrate:
     stage: test
-        image: paritytech/ci-linux
+        image: paritytech/ci-linux:production
         script:
             - cargo build ...
 ```


### PR DESCRIPTION
- `cargo-deny` [issue](https://github.com/EmbarkStudios/cargo-deny/issues/331#issuecomment-778617026) was fixed really fast
- better to have `mdbook` installed in the CI image, to fit the containers security policy: https://github.com/paritytech/polkadot/blob/e47912494b8d28a48be6a088c48ab9bf4e2205e1/.gitlab-ci.yml#L208