### PR TITLE
WIP: dockerfiles: new base starts off ubuntu 20.04, ink and contracts CI images inherit it

### DIFF
--- a/dockerfiles/base-ci/Dockerfile
+++ b/dockerfiles/base-ci/Dockerfile
@@ -1,0 +1,67 @@
+FROM ubuntu:20.04
+
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+ARG REGISTRY_PATH=paritytech
+
+# metadata
+LABEL summary="Layer 1 image with all dependencies for Rust and WASM compilation." \
+	name="${REGISTRY_PATH}/base-ci" \
+	maintainer="devops-team@parity.io" \
+	version="1.0" \
+	description="libssl-dev, clang, libclang-dev, lld, cmake, make, git, pkg-config \
+curl, time, rhash, rust stable, rust nightly, sccache" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/base-ci/Dockerfile" \
+	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/base-ci/README.md" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}"
+
+WORKDIR /builds
+
+# config for wasm32-unknown-unknown & clang
+COPY utility/base-ci-linux-config /root/.cargo/config
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+	CARGO_HOME=/usr/local/cargo \
+	PATH=/usr/local/cargo/bin:$PATH \
+		CC=clang \
+		CXX=clang \
+	DEBIAN_FRONTEND=noninteractive
+
+# install tools and dependencies
+RUN set -eux; \
+	apt-get -y update; \
+	apt-get install -y --no-install-recommends \
+		libssl-dev clang lld libclang-dev make cmake \
+		git pkg-config curl time rhash ca-certificates jq; \
+# set a link to clang
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
+# install rustup, use minimum components
+	curl -L "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
+		-o rustup-init; \
+  	chmod +x rustup-init; \
+  	./rustup-init -y --no-modify-path --profile minimal --default-toolchain stable; \
+  	rm rustup-init; \
+  	chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}; \
+# install sccache
+	# cargo install sccache --features redis; \
+	# FIXME: TEMPORARY OVERRIDE due to the sccache issue
+	# https://github.com/mozilla/sccache/issues/663
+	cargo install --git https://github.com/mozilla/sccache  --rev 6628e1f70db3d583cb5e79210603ad878de3d315 --features redis; \
+# versions
+	rustup show; \
+	cargo --version; \
+# cargo clean up
+# removes compilation artifacts cargo install creates (>250M)
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \
+# apt clean up
+	apt-get autoremove -y; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/lists/*
+# cache handler
+ENV	RUSTC_WRAPPER=sccache \
+# show backtraces
+  	RUST_BACKTRACE=1

--- a/dockerfiles/base-ci/Dockerfile
+++ b/dockerfiles/base-ci/Dockerfile
@@ -24,44 +24,46 @@ WORKDIR /builds
 # config for wasm32-unknown-unknown & clang
 COPY utility/base-ci-linux-config /root/.cargo/config
 
-ENV RUSTUP_HOME=/usr/local/rustup \
-	CARGO_HOME=/usr/local/cargo \
-	PATH=/usr/local/cargo/bin:$PATH \
-		CC=clang \
-		CXX=clang \
-	DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV	CARGO_HOME=/usr/local/cargo
+ENV	PATH=/usr/local/cargo/bin:$PATH
+ENV	CC=clang-10
+ENV CXX=/usr/bin/clang++-10
+ENV	DEBIAN_FRONTEND=noninteractive
 
 # install tools and dependencies
 RUN set -eux; \
-	apt-get -y update; \
+	apt-get -y update && \
 	apt-get install -y --no-install-recommends \
 		libssl-dev clang lld libclang-dev make cmake \
-		git pkg-config curl time rhash ca-certificates jq; \
+		git pkg-config curl time rhash ca-certificates jq && \
 # set a link to clang
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100; \
+	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 && \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 && \
+	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 && \
 # install rustup, use minimum components
 	curl -L "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
-		-o rustup-init; \
-  	chmod +x rustup-init; \
-  	./rustup-init -y --no-modify-path --profile minimal --default-toolchain stable; \
-  	rm rustup-init; \
-  	chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}; \
+		-o rustup-init && \
+  	chmod +x rustup-init && \
+  	./rustup-init -y --no-modify-path --profile minimal --default-toolchain stable && \
+  	rm rustup-init && \
+  	chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME} && \
 # install sccache
-	# cargo install sccache --features redis; \
+	# cargo install sccache --features redis && \
 	# FIXME: TEMPORARY OVERRIDE due to the sccache issue
 	# https://github.com/mozilla/sccache/issues/663
-	cargo install --git https://github.com/mozilla/sccache  --rev 6628e1f70db3d583cb5e79210603ad878de3d315 --features redis; \
+	cargo install --git https://github.com/mozilla/sccache  --rev 6628e1f70db3d583cb5e79210603ad878de3d315 --features redis && \
 # versions
-	rustup show; \
-	cargo --version; \
+	rustup show && \
+	cargo --version && \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
-	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
 # apt clean up
-	apt-get autoremove -y; \
-	apt-get clean; \
+	apt-get autoremove -y && \
+	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 # cache handler
-ENV	RUSTC_WRAPPER=sccache \
+ENV	RUSTC_WRAPPER=sccache
 # show backtraces
-  	RUST_BACKTRACE=1
+ENV RUST_BACKTRACE=1

--- a/dockerfiles/base-ci/README.md
+++ b/dockerfiles/base-ci/README.md
@@ -1,0 +1,37 @@
+# base-ci-linux
+
+Docker image based on [official Debian image](https://hub.docker.com/_/debian) debian:buster.
+
+Used as base for `Substrate`-based CI images.
+
+Our base CI image `<base-ci-linux:latest>`.
+
+Used to build and test Substrate-based projects.
+
+**Dependencies and Tools:**
+
+- `libssl-dev`
+- `clang-7`
+- `lld`
+- `libclang-dev`
+- `make`
+- `cmake`
+- `git`
+- `pkg-config`
+- `curl`
+- `time`
+- `rhash`
+- `ca-certificates`
+
+[Click here](https://hub.docker.com/repository/docker/paritytech/base-ci-linux) for the registry.
+
+**Rust tools & toolchains:**
+
+- stable (default)
+- `sccache`
+
+## Usage
+
+```Dockerfile
+FROM paritytech/base-ci-linux:latest
+```

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -50,7 +50,6 @@ RUN set -eux; \
 		-o /usr/local/cargo/bin/canvas && \
 	chmod +x /usr/local/cargo/bin/canvas && \
 # versions
-	# wasm-opt --version && \
 	yarn --version && \
 	rustup show && \
 	cargo --version && \
@@ -61,6 +60,7 @@ RUN set -eux; \
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
 # apt clean up
+	apt-get remove -y --purge python3 && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -2,7 +2,7 @@ ARG VCS_REF=master
 ARG BUILD_DATE=""
 ARG REGISTRY_PATH=paritytech
 
-FROM ${REGISTRY_PATH}/base-ci-linux:latest
+FROM ${REGISTRY_PATH}/base-ci:latest
 
 # metadata
 LABEL io.parity.image.authors="devops-team@parity.io" \
@@ -20,9 +20,9 @@ dockerfiles/contracts-ci-linux/README.md" \
 
 WORKDIR /builds
 
-ENV SHELL /bin/bash
-
-ENV CXX="/usr/bin/clang++-8"
+ENV SHELL /bin/bash \
+	CXX="/usr/bin/clang++-8" \
+	DEBIAN_FRONTEND=noninteractive
 
 # copy llvm repo key
 COPY utility/debian-llvm-clang.key /etc/apt/trusted.gpg.d/debian-archive-llvm.gpg

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -20,29 +20,22 @@ dockerfiles/contracts-ci-linux/README.md" \
 
 WORKDIR /builds
 
-ENV SHELL /bin/bash \
-	CXX="/usr/bin/clang++-8" \
-	DEBIAN_FRONTEND=noninteractive
-
-# copy llvm repo key
-COPY utility/debian-llvm-clang.key /etc/apt/trusted.gpg.d/debian-archive-llvm.gpg
+ENV SHELL /bin/bash
+ENV CXX=/usr/bin/clang++-10
+ENV DEBIAN_FRONTEND=noninteractive
 
 # install tools and dependencies
 RUN set -eux; \
-	echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
-		> /etc/apt/sources.list.d/llvm.list && \
-	echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
-		>> /etc/apt/sources.list.d/llvm.list && \
 	apt-get -y update && \
 	apt-get remove -y --purge clang && \
 	apt-get install -y --no-install-recommends \
-		zlib1g-dev llvm-8-dev clang-8 python3 npm wabt && \
+		zlib1g-dev python3 npm wabt llvm-dev && \
 	npm install --ignore-scripts -g yarn && \
-# set links to clang-8 and python3
+# set links to clang-10 and python3
 	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
-	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100 && \
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100 && \
-	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 100 && \
+	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 && \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 && \
+	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
@@ -57,7 +50,7 @@ RUN set -eux; \
 		-o /usr/local/cargo/bin/canvas && \
 	chmod +x /usr/local/cargo/bin/canvas && \
 # versions
-	wasm-opt --version && \
+	# wasm-opt --version && \
 	yarn --version && \
 	rustup show && \
 	cargo --version && \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
-llvm-8-dev, clang-8, python3, zlib1g-dev, npm, yarn, wabt, binaryen. \
+llvm-dev, clang, python3, zlib1g-dev, npm, yarn, wabt, binaryen. \
 rust nightly, rustfmt, rust-src, solang, canvas-node" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
@@ -27,15 +27,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # install tools and dependencies
 RUN set -eux; \
 	apt-get -y update && \
-	apt-get remove -y --purge clang && \
 	apt-get install -y --no-install-recommends \
 		zlib1g-dev python3 npm wabt llvm-dev && \
 	npm install --ignore-scripts -g yarn && \
 # set links to clang-10 and python3
 	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
-	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 && \
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 && \
-	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -30,44 +30,44 @@ COPY utility/debian-llvm-clang.key /etc/apt/trusted.gpg.d/debian-archive-llvm.gp
 # install tools and dependencies
 RUN set -eux; \
 	echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
-		> /etc/apt/sources.list.d/llvm.list; \
+		> /etc/apt/sources.list.d/llvm.list && \
 	echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" \
-		>> /etc/apt/sources.list.d/llvm.list; \
-	apt-get -y update; \
-	apt-get remove -y --purge clang; \
+		>> /etc/apt/sources.list.d/llvm.list && \
+	apt-get -y update && \
+	apt-get remove -y --purge clang && \
 	apt-get install -y --no-install-recommends \
-		zlib1g-dev llvm-8-dev clang-8 python3 npm wabt binaryen; \
-	npm install --ignore-scripts -g yarn; \
+		zlib1g-dev llvm-8-dev clang-8 python3 npm wabt && \
+	npm install --ignore-scripts -g yarn && \
 # set links to clang-8 and python3
-	update-alternatives --install /usr/bin/python python /usr/bin/python3 100; \
-	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100; \
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100; \
-	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 100; \
+	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
+	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100 && \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-8 100 && \
+	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-8 100 && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
-		--profile minimal --component rustfmt rust-src; \
-	rustup default nightly; \
-	cargo install pwasm-utils-cli --bin wasm-prune; \
-	cargo install cargo-contract; \
+		--profile minimal --component rustfmt rust-src && \
+	rustup default nightly && \
+	cargo install pwasm-utils-cli --bin wasm-prune && \
+	cargo install --features binaryen-as-dependency cargo-contract && \
 # tried v0.1.5 and the latest master - both fail with https://github.com/hyperledger-labs/solang/issues/314
-	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.2; \
+	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.2 && \
 # download the latest canvas-node binary
 	curl -L "https://gitlab.parity.io/parity/canvas-node/-/jobs/artifacts/master/raw/artifacts/canvas/canvas?job=build" \
-		-o /usr/local/cargo/bin/canvas; \
-	chmod +x /usr/local/cargo/bin/canvas; \
+		-o /usr/local/cargo/bin/canvas && \
+	chmod +x /usr/local/cargo/bin/canvas && \
 # versions
-	wasm-opt --version; \
-	yarn --version; \
-	rustup show; \
-	cargo --version; \
-	solang --version; \
-	canvas --version; \
-	python --version; \
+	wasm-opt --version && \
+	yarn --version && \
+	rustup show && \
+	cargo --version && \
+	solang --version && \
+	canvas --version && \
+	python --version && \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
-	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
 # apt clean up
-	apt-get autoremove -y; \
-	apt-get clean; \
+	apt-get autoremove -y && \
+	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -1,20 +1,19 @@
 # contracts! CI for Linux Distributions
 
-Docker image based on our base CI image `<base-ci-linux:latest>`.
+Docker image based on our base CI image `<base-ci:latest>`.
 
 Used to build and test contracts!.
 
 ## Dependencies and Tools
 
-- `llvm-8-dev`
-- `clang-8`
+- `llvm-dev`
+- `clang-10`
 - `zlib1g-dev`
-- `python3`
 - `npm`
 - `yarn`
 - `wabt`
 
-**Inherited from `<base-ci-linux:latest>`:**
+**Inherited from `<base-ci:latest>`**
 
 - `libssl-dev`
 - `lld`
@@ -50,7 +49,7 @@ We always try to use the [latest possible](https://rust-lang.github.io/rustup-co
 ```yaml
 test-contracts:
     stage: test
-        image: paritytech/contracts-ci-linux:latest
+        image: paritytech/contracts-ci-linux:production
         script:
             - cargo build ...
 ```

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -2,7 +2,7 @@ ARG VCS_REF=master
 ARG BUILD_DATE
 ARG REGISTRY_PATH=paritytech
 
-FROM ${REGISTRY_PATH}/base-ci-linux:latest
+FROM ${REGISTRY_PATH}/base-ci:latest
 
 # metadata
 LABEL io.parity.image.authors="devops-team@parity.io" \
@@ -19,7 +19,8 @@ dockerfiles/ink-ci-linux/README.md" \
 
 WORKDIR /builds
 
-ENV SHELL /bin/bash
+ENV SHELL /bin/bash \
+	DEBIAN_FRONTEND=noninteractive
 
 RUN	set -eux; \
 # The supported Rust nightly version must support the following components

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -24,6 +24,16 @@ ENV CXX=/usr/bin/clang++-10
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN	set -eux; \
+	apt-get -y update && \
+	apt-get remove -y --purge clang && \
+	apt-get install -y --no-install-recommends \
+# python3 is only needed to install binaryen for contracts
+		python3 && \
+# set links to clang-10 and python3
+	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
+	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 && \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 && \
+	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 && \
 # The supported Rust nightly version must support the following components
 # to allow for a functioning CI pipeline:
 #
@@ -37,14 +47,6 @@ RUN	set -eux; \
 #
 # Only Rust nightly builds supporting all of the above mentioned components
 # and targets can be used for this docker image.
-	apt-get -y update && \
-	apt-get remove -y --purge clang && \
-	apt-get install -y --no-install-recommends \
-		python3 && \
-	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
-	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 && \
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 && \
-	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -19,8 +19,9 @@ dockerfiles/ink-ci-linux/README.md" \
 
 WORKDIR /builds
 
-ENV SHELL /bin/bash \
-	DEBIAN_FRONTEND=noninteractive
+ENV SHELL /bin/bash
+ENV CXX=/usr/bin/clang++-10
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN	set -eux; \
 # The supported Rust nightly version must support the following components
@@ -36,7 +37,14 @@ RUN	set -eux; \
 #
 # Only Rust nightly builds supporting all of the above mentioned components
 # and targets can be used for this docker image.
-#
+	apt-get -y update && \
+	apt-get remove -y --purge clang && \
+	apt-get install -y --no-install-recommends \
+		python3 && \
+	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
+	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 && \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 && \
+	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
@@ -45,14 +53,16 @@ RUN	set -eux; \
 # We require `xargo` so that `miri` runs properly
 # We require `grcov` for coverage reporting and `rust-covfix` to improve it.
 	cargo install grcov rust-covfix xargo && \
-	cargo install --features binaryen-as-dependency cargo-contract && \
 # `cargo-contract` requires `binaryen` for optimizing Wasm files
-	apt-get -y update && \
-	apt-get install -y --no-install-recommends && \
+	cargo install --features binaryen-as-dependency cargo-contract && \
 # versions
 	rustup show && \
 	cargo --version && \
-	wasm-opt --version && \
 	cargo-contract --version && \
 # Clean up and remove compilation artifacts that a cargo install creates (>250M).
-	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache;
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
+# apt clean up
+	apt-get remove -y --purge python3 && \
+	apt-get autoremove -y && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -25,15 +25,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN	set -eux; \
 	apt-get -y update && \
-	apt-get remove -y --purge clang && \
 	apt-get install -y --no-install-recommends \
 # python3 is only needed to install binaryen for contracts
 		python3 && \
 # set links to clang-10 and python3
 	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
-	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100 && \
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100 && \
-	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100 && \
 # The supported Rust nightly version must support the following components
 # to allow for a functioning CI pipeline:
 #

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -40,22 +40,19 @@ RUN	set -eux; \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
-		--profile minimal --component rustfmt clippy miri rust-src; \
-	rustup default nightly; \
+		--profile minimal --component rustfmt clippy miri rust-src && \
+	rustup default nightly && \
 # We require `xargo` so that `miri` runs properly
 # We require `grcov` for coverage reporting and `rust-covfix` to improve it.
-	cargo install grcov rust-covfix xargo cargo-contract; \
+	cargo install grcov rust-covfix xargo && \
+	cargo install --features binaryen-as-dependency cargo-contract && \
 # `cargo-contract` requires `binaryen` for optimizing Wasm files
-	apt-get -y update; \
-	apt-get install -y --no-install-recommends binaryen; \
+	apt-get -y update && \
+	apt-get install -y --no-install-recommends && \
 # versions
-	rustup show; \
-	cargo --version; \
-	wasm-opt --version; \
-	cargo-contract --version; \
+	rustup show && \
+	cargo --version && \
+	wasm-opt --version && \
+	cargo-contract --version && \
 # Clean up and remove compilation artifacts that a cargo install creates (>250M).
-	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache; \
-# apt clean up
-	apt-get autoremove -y; \
-	apt-get clean; \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache;

--- a/dockerfiles/ink-ci-linux/README.md
+++ b/dockerfiles/ink-ci-linux/README.md
@@ -1,15 +1,15 @@
 # ink! CI for Linux Distributions
 
-Docker image based on our base CI image `<base-ci-linux:latest>`.
+Docker image based on our base CI image `<base-ci:latest>`.
 
 Used to build and test ink!.
 
 ## Dependencies and Tools
 
-**Inherited from `<base-ci-linux:latest>`:**
+**Inherited from `<base-ci:latest>`**
 
 - `libssl-dev`
-- `clang-7`
+- `clang-10`
 - `lld`
 - `libclang-dev`
 - `make`


### PR DESCRIPTION
- new `base-ci`, now powered by `ubuntu:20.04`
- `contracts-ci-linux` and `ink-ci-linux` are rebased to the new base image
- `contracts-ci-linux` gets `clang10` from ubuntu 
  image compiles and works, currently published under `paritytech/contracts-ci-linux:ubuntu` @cmichi please check, I'm not sure what's with `wasm-opt` and if it's still needed.
- pretty much the same with `ink-ci-linux`, unless it's not ready now.