### PR TITLE
dockerfiles: undelete python3 from contracts image

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -56,7 +56,6 @@ RUN set -eux; \
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
 # apt clean up
-	apt-get remove -y --purge python3 && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -12,6 +12,7 @@ Used to build and test contracts!.
 - `npm`
 - `yarn`
 - `wabt`
+- `python3`
 
 **Inherited from `<base-ci:latest>`**
 


### PR DESCRIPTION
it's needed for CI