### PR TITLE
dockerfiles: add vault binary in terraform image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -206,6 +206,8 @@ terraform:
     <<:                            *default-vars
     # https://releases.hashicorp.com/terraform/
     TERRAFORM_VERSION:             "0.13.5"
+    # https://releases.hashicorp.com/vault/
+    VAULT_VERSION:                 "1.6.3"
   script:
     - |
       cat <<-EOT
@@ -213,6 +215,7 @@ terraform:
       | # build of terraform image
       |
       | TERRAFORM_VERSION = $TERRAFORM_VERSION
+      | VAULT_VERSION     = $VAULT_VERSION
       |
       EOT
     - buildah bud
@@ -221,6 +224,7 @@ terraform:
       --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
       --build-arg REGISTRY_PATH="$REGISTRY_PATH"
       --build-arg TERRAFORM_VERSION="$TERRAFORM_VERSION"
+      --build-arg VAULT_VERSION="$VAULT_VERSION"
       --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
       --tag "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
       --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles

--- a/dockerfiles/terraform/Dockerfile
+++ b/dockerfiles/terraform/Dockerfile
@@ -4,6 +4,7 @@ ARG VCS_REF=master
 ARG BUILD_DATE=""
 ARG REGISTRY_PATH=paritytech
 ARG TERRAFORM_VERSION
+ARG VAULT_VERSION
 
 # metadata
 LABEL io.parity.image.authors="devops-team@parity.io" \
@@ -24,6 +25,12 @@ RUN apk add --no-cache \
 	unzip terraform.zip	-d /usr/local/bin/ terraform; \
 	rm terraform.zip; \
 	chmod +x /usr/local/bin/terraform
+
+RUN	curl "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" \
+		-o vault.zip; \
+	unzip vault.zip	-d /usr/local/bin/ vault; \
+	rm vault.zip; \
+	chmod +x /usr/local/bin/vault
 
 WORKDIR /config
 

--- a/dockerfiles/terraform/README.md
+++ b/dockerfiles/terraform/README.md
@@ -1,1 +1,1 @@
-Image with Terraform.
+Image containing the Terraform and Vault binaries.


### PR DESCRIPTION
The goal of this PR is to add the vault binary to the `paritytech/terraform` image to be able to use the vault client CLI in terraform pipelines in order to retrieve secrets.