### PR TITLE
node-bench-regression-guard: ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,6 +125,11 @@ redis-exporter:
   script:
     - *push_to_docker_hub
 
+node-bench-regression-guard:
+  <<:                              *docker_build
+  script:
+    - *push_to_docker_hub
+
 # special case as version tags are introduced
 kubetools:
   <<:                              *docker_build


### PR DESCRIPTION
Allows to build `node-bench-regression-guard` image via the relevant pipeline.