### PR TITLE
dockerfiles: add sops docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,6 +241,43 @@ terraform:
     - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$TERRAFORM_VERSION"
     - buildah logout "$REGISTRY_PATH"
 
+sops:
+  <<:                              *docker_build
+  variables:
+    <<:                            *default-vars
+    # https://github.com/mozilla/sops/releases/
+    SOPS_VERSION:                  "3.7.0"
+    # https://releases.hashicorp.com/vault/
+    VAULT_VERSION:                 "1.6.3"
+  script:
+    - |
+      cat <<-EOT
+      |
+      | # build of terraform image
+      |
+      | SOPS_VERSION      = $SOPS_VERSION
+      | VAULT_VERSION     = $VAULT_VERSION
+      |
+      EOT
+    - buildah bud
+      --format=docker
+      --build-arg VCS_REF="$CI_COMMIT_SHA"
+      --build-arg BUILD_DATE="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+      --build-arg REGISTRY_PATH="$REGISTRY_PATH"
+      --build-arg SOPS_VERSION="$SOPS_VERSION"
+      --build-arg VAULT_VERSION="$VAULT_VERSION"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$SOPS_VERSION"
+      --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
+    # Push to Dockerhub
+    - echo "$DOCKER_PASSWORD" |
+        buildah login --username "$DOCKER_USER" --password-stdin "$REGISTRY_PATH"
+    - buildah info
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:latest"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$SOPS_VERSION"
+    - buildah logout "$REGISTRY_PATH"
+
+
 #### stage:                        test
 
 container_scanning:

--- a/dockerfiles/sops/Dockerfile
+++ b/dockerfiles/sops/Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:latest
+
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+ARG REGISTRY_PATH=paritytech
+ARG SOPS_VERSION
+ARG VAULT_VERSION
+
+# metadata
+LABEL io.parity.image.authors="devops-team@parity.io" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.title="${REGISTRY_PATH}/sops" \
+	io.parity.image.description="ca-certificates git jq make curl gettext; sops;" \
+	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/terraform/Dockerfile" \
+	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/terraform/README.md" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}"
+
+RUN apk add --no-cache \
+		ca-certificates git jq make curl gettext; \
+	curl -L "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux"  \
+		-o /usr/local/bin/sops; \
+	chmod +x /usr/local/bin/sops
+
+RUN	curl "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" \
+		-o vault.zip; \
+	unzip vault.zip	-d /usr/local/bin/ vault; \
+	rm vault.zip; \
+	chmod +x /usr/local/bin/vault
+
+WORKDIR /config
+
+CMD ["/bin/sh"]

--- a/dockerfiles/sops/README.md
+++ b/dockerfiles/sops/README.md
@@ -1,0 +1,1 @@
+Image containing the Sops and Vault binaries.


### PR DESCRIPTION
Add a docker image containing sops for encrypting and decrypting secrets contained in files using an encryption-as-a-service provider (KMS) such as Vault.
The vault binary is added for convenience to preform login operations on Vault and get the vault token that will be passed to sops.