### PR TITLE
refactor sccache CI image

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -8,7 +8,7 @@ FROM ${REGISTRY_PATH}/base-ci:latest
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/ink-ci-linux" \
-	io.parity.image.description="Inherits from base-ci-linux:latest. \
+	io.parity.image.description="Inherits from paritytech/base-ci. \
 rust nightly, clippy, rustfmt, miri, rust-src grcov, rust-covfix, cargo-contract, xargo, binaryen" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/ink-ci-linux/Dockerfile" \

--- a/dockerfiles/sccache-ci-ubuntu/Dockerfile
+++ b/dockerfiles/sccache-ci-ubuntu/Dockerfile
@@ -1,17 +1,16 @@
-FROM ubuntu:20.10
-
 ARG VCS_REF=master
-ARG BUILD_DATE=""
+ARG BUILD_DATE
 ARG REGISTRY_PATH=paritytech
 
+FROM ${REGISTRY_PATH}/base-ci:latest
+
 # metadata
-LABEL summary="CI image with all dependencies for sccache compilation." \
-	name="${REGISTRY_PATH}/sccache-ci-linux" \
-	maintainer="devops-team@parity.io" \
-	version="1.0" \
-	description="libssl-dev, clang, libclang-dev, lld, cmake, make, git, pkg-config \
-curl, time, rhash, rust stable, rust nightly, sccache" \
+LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.title="${REGISTRY_PATH}/sccache-ci-linux" \
+	io.parity.image.description="CI image with all dependencies for sccache compilation. \
+Inherits from base-ci-linux:latest. libssl-dev, clang, libclang-dev, lld, cmake, make, \
+git, pkg-config curl, time, rhash, rust stable, rust nightly, sccache" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/sccache-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -21,25 +20,23 @@ dockerfiles/sccache-ci-linux/README.md" \
 
 WORKDIR /builds
 
+ENV SHELL /bin/bash
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TERM=xterm-256color
+ENV LD_LIBRARY_PATH=/usr/local/cuda-11.1/lib64
+ENV PATH=/usr/local/cargo/bin:/usr/local/cuda-11.1/bin:$PATH
+ENV CC=clang
+ENV CXX=clang
+
 # config for wasm32-unknown-unknown & clang
 COPY utility/base-ci-linux-config /root/.cargo/config
-
-ENV RUSTUP_HOME=/usr/local/rustup \
-	CARGO_HOME=/usr/local/cargo \
-	PATH=/usr/local/cargo/bin:/usr/local/cuda-11.1/bin:$PATH \
-	CC=clang \
-	CXX=clang \
-    LD_LIBRARY_PATH=/usr/local/cuda-11.1/lib64 \
-    DEBIAN_FRONTEND=noninteractive \
-    TERM=xterm-256color
 
 # install tools and dependencies
 RUN set -eux && \
 	apt-get -y update && \
 	apt-get install -y --no-install-recommends \
-		linux-headers-5.8.0-29 libssl-dev clang libclang-dev gcc binutils coreutils gdbserver \
-        zlib1g-dev librust-zip+deflate-miniz-dev curl gnupg2 docker \
-        lld make cmake git pkg-config time rhash ca-certificates && \
+		linux-headers-5.8.0-29 gcc binutils coreutils gdbserver \
+        zlib1g-dev librust-zip+deflate-miniz-dev gnupg2 docker && \
 # setup nvcc
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub | apt-key add - && \
     echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \
@@ -47,20 +44,10 @@ RUN set -eux && \
     apt-get install -y --no-install-recommends \
         cuda-command-line-tools-11-1=11.1.1-1 && \
     ln -s cuda-11.1 /usr/local/cuda && \
-# set a link to clang
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100 && \
 # install rustup, use minimum components
-	curl -L "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" -o rustup-init && \
-  	chmod +x rustup-init && \
-  	./rustup-init -y --no-modify-path --profile minimal --default-toolchain nightly --component clippy rustfmt && \
-  	rm rustup-init && \
-  	chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME} && \
-    rustup toolchain install stable --profile minimal && \
-# install sccache
-	# cargo install sccache --features redis && \
-	# FIXME: TEMPORARY OVERRIDE due to the sccache issue
-	# https://github.com/mozilla/sccache/issues/663
-	cargo install --git https://github.com/mozilla/sccache  --rev 6628e1f70db3d583cb5e79210603ad878de3d315 --features redis && \
+	rustup toolchain install stable --profile minimal --component clippy rustfmt && \
+	rustup default stable && \
+    rustup toolchain install nightly --profile minimal && \
     cargo install broot ripgrep sd && \
 # versions
 	rustup show && \

--- a/dockerfiles/sccache-ci-ubuntu/Dockerfile
+++ b/dockerfiles/sccache-ci-ubuntu/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/sccache-ci-linux" \
 	io.parity.image.description="CI image with all dependencies for sccache compilation. \
-Inherits from base-ci-linux:latest. libssl-dev, clang, libclang-dev, lld, cmake, make, \
+Inherits from paritytech/base-ci. libssl-dev, clang, libclang-dev, lld, cmake, make, \
 git, pkg-config curl, time, rhash, rust stable, rust nightly, sccache" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/sccache-ci-linux/Dockerfile" \


### PR DESCRIPTION
- now it depends on the [common ubuntu base image](https://github.com/paritytech/scripts/tree/master/dockerfiles/ci-linux), hence builds faster and much lighter.
- rust `stable` is the default
- `nightly` is installed with a minimal profile