### PR TITLE
Remove `--binaryen-as-dependency`

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -9,7 +9,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
-llvm-dev, clang, python3, zlib1g-dev, npm, yarn, wabt, binaryen. \
+llvm-dev, clang, zlib1g-dev, npm, yarn, wabt, binaryen. \
 rust nightly, rustfmt, clippy, rust-src, solang, canvas-node" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
@@ -21,24 +21,21 @@ dockerfiles/contracts-ci-linux/README.md" \
 WORKDIR /builds
 
 ENV SHELL /bin/bash
-ENV CXX=/usr/bin/clang++-10
 ENV DEBIAN_FRONTEND=noninteractive
 
 # install tools and dependencies
 RUN set -eux; \
 	apt-get -y update && \
 	apt-get install -y --no-install-recommends \
-		zlib1g-dev python3 npm wabt llvm-dev && \
+		zlib1g-dev binaryen npm wabt llvm-dev && \
 	npm install --ignore-scripts -g yarn && \
-# set links to clang-10 and python3
-	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy rust-src && \
 	rustup default nightly && \
 	cargo install pwasm-utils-cli --bin wasm-prune && \
-	cargo install --features binaryen-as-dependency cargo-contract && \
+	cargo install cargo-contract && \
 # tried v0.1.5 and the latest master - both fail with https://github.com/hyperledger-labs/solang/issues/314
 	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.2 && \
 # download the latest canvas-node binary
@@ -51,7 +48,6 @@ RUN set -eux; \
 	cargo --version && \
 	solang --version && \
 	canvas --version && \
-	python --version && \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -7,12 +7,11 @@ Used to build and test contracts!.
 ## Dependencies and Tools
 
 - `llvm-dev`
-- `clang-10`
 - `zlib1g-dev`
 - `npm`
 - `yarn`
 - `wabt`
-- `python3`
+- `binaryen`
 
 **Inherited from `<base-ci:latest>`**
 

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -26,11 +26,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN	set -eux; \
 	apt-get -y update && \
 	apt-get install -y --no-install-recommends \
-# python3 is only needed to install binaryen for contracts
+# binaryen is needed by cargo-contract for optimizing Wasm files
 # hunspell is needed for automated spell-checking
-		python3 hunspell hunspell-en-us && \
-# set links to clang-10 and python3
-	update-alternatives --install /usr/bin/python python /usr/bin/python3 100 && \
+	binaryen hunspell hunspell-en-us && \
 # The supported Rust nightly version must support the following components
 # to allow for a functioning CI pipeline:
 #
@@ -53,8 +51,7 @@ RUN	set -eux; \
 # We require `grcov` for coverage reporting and `rust-covfix` to improve it.
 # We require `cargo-spellcheck` for automated spell-checking
 	cargo install grcov rust-covfix xargo cargo-spellcheck && \
-# `cargo-contract` requires `binaryen` for optimizing Wasm files
-	cargo install --features binaryen-as-dependency cargo-contract && \
+	cargo install cargo-contract && \
 # versions
 	rustup show && \
 	cargo --version && \
@@ -62,7 +59,6 @@ RUN	set -eux; \
 # Clean up and remove compilation artifacts that a cargo install creates (>250M).
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
 # apt clean up
-	apt-get remove -y --purge python3 && \
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/ink-ci-linux/README.md
+++ b/dockerfiles/ink-ci-linux/README.md
@@ -9,9 +9,7 @@ Used to build and test ink!.
 **Inherited from `<base-ci:latest>`**
 
 - `libssl-dev`
-- `clang-10`
 - `lld`
-- `libclang-dev`
 - `make`
 - `cmake`
 - `git`
@@ -20,6 +18,7 @@ Used to build and test ink!.
 - `time`
 - `rhash`
 - `ca-certificates`
+- `binaryen`
 
 **Rust versions:**
 


### PR DESCRIPTION
Closes https://github.com/paritytech/ci_cd/issues/121.

I tested it locally via
```
docker build -t contracts-ci 
docker run -it contracts-ci
7ca83609797f:/builds# cargo-contract --version                            
cargo-contract 0.11.1-unknown-x86_64-linux-gnu
```