### PR TITLE
Use fully qualified image names in Dockerfiles

### DIFF
--- a/dockerfiles/ansible/Dockerfile
+++ b/dockerfiles/ansible/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-stretch
+FROM docker.io/library/python:3.7.6-stretch
 
 # metadata
 ARG VCS_REF=master

--- a/dockerfiles/awscli/Dockerfile
+++ b/dockerfiles/awscli/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM docker.io/library/python:3.6-alpine
 
 # metadata
 ARG VCS_REF=master

--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM docker.io/library/debian:buster-slim
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""

--- a/dockerfiles/base-ci/Dockerfile
+++ b/dockerfiles/base-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""

--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -1,6 +1,6 @@
 ARG VCS_REF=master
 ARG BUILD_DATE=""
-ARG REGISTRY_PATH=paritytech
+ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/base-ci-linux:latest
 

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -1,6 +1,6 @@
 ARG VCS_REF=master
 ARG BUILD_DATE=""
-ARG REGISTRY_PATH=paritytech
+ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/base-ci:latest
 

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -1,6 +1,6 @@
 ARG VCS_REF=master
 ARG BUILD_DATE
-ARG REGISTRY_PATH=paritytech
+ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/base-ci:latest
 

--- a/dockerfiles/ink-waterfall-ci/Dockerfile
+++ b/dockerfiles/ink-waterfall-ci/Dockerfile
@@ -1,6 +1,6 @@
 ARG VCS_REF=master
 ARG BUILD_DATE
-ARG REGISTRY_PATH=paritytech
+ARG REGISTRY_PATH=docker.io/paritytech
 
 # `production` tag is used here to base off the image that has already been tested against
 # the `ink` CI. This reduces the maintenance of fixing the same nightly stuff in both images.

--- a/dockerfiles/kubetools/Dockerfile
+++ b/dockerfiles/kubetools/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""

--- a/dockerfiles/kubetools/helm3.Dockerfile
+++ b/dockerfiles/kubetools/helm3.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""

--- a/dockerfiles/node-bench-regression-guard/Dockerfile
+++ b/dockerfiles/node-bench-regression-guard/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine
+FROM docker.io/library/ruby:2.7-alpine
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""

--- a/dockerfiles/query-exporter/Dockerfile
+++ b/dockerfiles/query-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM docker.io/library/python:3-alpine
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""

--- a/dockerfiles/redis-exporter/Dockerfile
+++ b/dockerfiles/redis-exporter/Dockerfile
@@ -1,5 +1,5 @@
 #docker image from https://github.com/oliver006/redis_exporter
-FROM golang:1.13-alpine as builder
+FROM docker.io/library/golang:1.13-alpine as builder
 
 RUN apk --no-cache add ca-certificates git
 
@@ -7,7 +7,7 @@ RUN go get github.com/oliver006/redis_exporter
 RUN cd ${GOPATH}/src/github.com/oliver006/redis_exporter && go build
 
 
-FROM alpine as alpine
+FROM docker.io/library/alpine as alpine
 COPY --from=builder /go/src/github.com/oliver006/redis_exporter/redis_exporter /redis_exporter
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 

--- a/dockerfiles/sccache-ci-ubuntu/Dockerfile
+++ b/dockerfiles/sccache-ci-ubuntu/Dockerfile
@@ -1,6 +1,6 @@
 ARG VCS_REF=master
 ARG BUILD_DATE
-ARG REGISTRY_PATH=paritytech
+ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/base-ci:latest
 

--- a/dockerfiles/sops/Dockerfile
+++ b/dockerfiles/sops/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""

--- a/dockerfiles/terraform/Dockerfile
+++ b/dockerfiles/terraform/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""

--- a/dockerfiles/tools/Dockerfile
+++ b/dockerfiles/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""


### PR DESCRIPTION
Don't use shortnames, especially with Red Hat containers tools.