### PR TITLE
Add non-root user for the ops tooling images

### DIFF
--- a/dockerfiles/awscli/Dockerfile
+++ b/dockerfiles/awscli/Dockerfile
@@ -17,9 +17,14 @@ dockerfiles/awscli/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 RUN pip install awscli; \
-	apk add --no-cache bash
+	apk add --no-cache bash shadow
+
+RUN set -x \
+    && groupadd -g 1000 nonroot \
+    && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot
 
 COPY utility/awscli-config /etc/aws.config
 ENV AWS_CONFIG_FILE /etc/aws.config
 
-CMD ["/bin/sh"]
+USER nonroot:nonroot
+CMD ["/bin/bash"]

--- a/dockerfiles/kubetools/Dockerfile
+++ b/dockerfiles/kubetools/Dockerfile
@@ -19,7 +19,7 @@ dockerfiles/kubetools/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 RUN apk add --no-cache \
-		ca-certificates git jq make curl gettext; \
+		ca-certificates git jq make curl gettext bash shadow; \
 	curl -L "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
 		-o /usr/local/bin/kubectl; \
 	curl -L "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" \
@@ -30,6 +30,13 @@ RUN apk add --no-cache \
 	chmod +x /usr/local/bin/kubectl; \
 	chmod +x /usr/local/bin/helm
 
+RUN set -x \
+    && groupadd -g 1000 nonroot \
+    && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot \
+    && mkdir /config \
+    && chown nonroot:nonroot /config
+
 WORKDIR /config
 
-CMD ["/bin/sh"]
+USER nonroot:nonroot
+CMD ["/bin/bash"]

--- a/dockerfiles/kubetools/helm3.Dockerfile
+++ b/dockerfiles/kubetools/helm3.Dockerfile
@@ -19,7 +19,7 @@ dockerfiles/kubetools/README.md" \
     io.parity.image.created="${BUILD_DATE}"
 
 RUN apk add --no-cache \
-        ca-certificates git jq make curl gettext && \
+        ca-certificates git jq make curl gettext bash shadow && \
     # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
     curl -L "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
         -o /usr/local/bin/kubectl && \
@@ -35,6 +35,13 @@ RUN apk add --no-cache \
     kubectl version --short=true --client && \
     helm version
 
+RUN set -x \
+    && groupadd -g 1000 nonroot \
+    && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot \
+    && mkdir /config \
+    && chown nonroot:nonroot /config
+
 WORKDIR /config
 
-    CMD ["/bin/sh"]
+USER nonroot:nonroot
+CMD ["/bin/bash"]

--- a/dockerfiles/node-bench-regression-guard/Dockerfile
+++ b/dockerfiles/node-bench-regression-guard/Dockerfile
@@ -11,7 +11,12 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
       io.parity.image.revision="${VCS_REF}" \
       io.parity.image.created="${BUILD_DATE}"
 
-RUN apk add --no-cache --update curl unzip
+RUN apk add --no-cache --update curl unzip bash shadow
 COPY node-bench-regression-guard/node-bench-regression-guard /usr/local/bin/node-bench-regression-guard
 
+RUN set -x \
+    && groupadd -g 1000 nonroot \
+    && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot
+
+USER nonroot:nonroot
 CMD ["node-bench-regression-guard", "--help"]

--- a/dockerfiles/query-exporter/Dockerfile
+++ b/dockerfiles/query-exporter/Dockerfile
@@ -13,12 +13,16 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
   io.parity.image.created="${BUILD_DATE}"
 
 RUN \
-  apk add --no-cache postgresql-libs && \
+  apk add --no-cache postgresql-libs bash shadow && \
 	apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev && \
 	python3 -m pip install --no-cache-dir SQLAlchemy[postgresql] query-exporter && \
 	apk --purge del .build-deps
 
+RUN set -x \
+    && groupadd -g 1000 nonroot \
+    && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot
 
 EXPOSE 9560
 
+USER nonroot:nonroot
 ENTRYPOINT ["python3", "/usr/local/bin/query-exporter"]

--- a/dockerfiles/sops/Dockerfile
+++ b/dockerfiles/sops/Dockerfile
@@ -19,7 +19,7 @@ dockerfiles/terraform/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 RUN apk add --no-cache \
-		ca-certificates git jq make curl gettext; \
+		ca-certificates git jq make curl gettext bash shadow; \
 	curl -L "https://github.com/mozilla/sops/releases/download/v${SOPS_VERSION}/sops-v${SOPS_VERSION}.linux"  \
 		-o /usr/local/bin/sops; \
 	chmod +x /usr/local/bin/sops
@@ -30,6 +30,13 @@ RUN	curl "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VE
 	rm vault.zip; \
 	chmod +x /usr/local/bin/vault
 
+RUN set -x \
+    && groupadd -g 1000 nonroot \
+    && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot \
+    && mkdir /config \
+    && chown nonroot:nonroot /config
+
 WORKDIR /config
 
-CMD ["/bin/sh"]
+USER nonroot:nonroot
+CMD ["/bin/bash"]

--- a/dockerfiles/terraform/Dockerfile
+++ b/dockerfiles/terraform/Dockerfile
@@ -19,7 +19,7 @@ dockerfiles/terraform/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 RUN apk add --no-cache \
-		ca-certificates git jq make curl gettext; \
+		ca-certificates git jq make curl gettext bash shadow; \
 	curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
 		-o terraform.zip; \
 	unzip terraform.zip	-d /usr/local/bin/ terraform; \
@@ -32,6 +32,13 @@ RUN	curl "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VE
 	rm vault.zip; \
 	chmod +x /usr/local/bin/vault
 
+RUN set -x \
+    && groupadd -g 1000 nonroot \
+    && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot \
+    && mkdir /config \
+    && chown nonroot:nonroot /config
+
 WORKDIR /config
 
-CMD ["/bin/sh"]
+USER nonroot:nonroot
+CMD ["/bin/bash"]

--- a/dockerfiles/tools/Dockerfile
+++ b/dockerfiles/tools/Dockerfile
@@ -19,7 +19,7 @@ dockerfiles/tools/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 
-RUN apk add --no-cache curl git jq rsync make gettext gnupg bash
+RUN apk add --no-cache curl git jq rsync make gettext gnupg bash shadow
 
 RUN curl -sS -L "https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz" \
   		--output prometheus.tar.gz && \
@@ -27,4 +27,9 @@ RUN curl -sS -L "https://github.com/prometheus/prometheus/releases/download/v${P
 	mv prometheus-${PROM_VERSION}.linux-amd64/promtool /usr/local/bin && \
 	rm -rf prometheus.tar.gz prometheus-${PROM_VERSION}.linux-amd64
 
-CMD ["/bin/sh"]
+RUN set -x \
+    && groupadd -g 1000 nonroot \
+    && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot
+
+USER nonroot:nonroot
+CMD ["/bin/bash"]


### PR DESCRIPTION
Relates to paritytech/ci_cd#92.

This PR adds non-root user only for ops tooling images as per my comment [here](https://github.com/paritytech/ci_cd/issues/92#issuecomment-847926377).

Please review the changes. After the merge, I'll rebuild the affected images.