### PR TITLE
Temporary switch back to `root` for some images

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -67,4 +67,5 @@ RUN set -eux; \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-USER nonroot:nonroot
+# TODO: https://gitlab.parity.io/parity/cargo-contract/-/jobs/958744, https://gitlab.parity.io/parity/cargo-contract/-/jobs/958745
+# USER nonroot:nonroot

--- a/dockerfiles/ink-waterfall-ci/Dockerfile
+++ b/dockerfiles/ink-waterfall-ci/Dockerfile
@@ -78,4 +78,5 @@ RUN	set -eux; \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-USER nonroot:nonroot
+# TODO: https://gitlab.parity.io/parity/infrastructure/scripts/-/jobs/958687
+# USER nonroot:nonroot


### PR DESCRIPTION
`ci-linux` still runs as `root`, so I revert this too until we resolve downstream issues. Failing jobs are mentioned in `TODO` comments.

Why would I do this? Stable Rust has to be updated sometimes and it's not possible to update such "hanging" images while there are unrelated issues.