### PR TITLE
Pin Rust nightly to 2021-04-22 for `paritytech/ci-linux`

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -27,7 +27,7 @@ RUN set -eux && \
 # install `rust-src` component for ui test
 	rustup component add rust-src && \
 # install Rust nightly, default is stable, use minimum components
-	rustup toolchain install nightly --profile minimal && \
+	rustup toolchain install nightly-2021-04-22 --profile minimal && \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \

--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -26,8 +26,10 @@ RUN set -eux && \
 		chromium-driver && \
 # install `rust-src` component for ui test
 	rustup component add rust-src && \
-# install Rust nightly, default is stable, use minimum components
+# install specific Rust nightly, default is stable, use minimum components
 	rustup toolchain install nightly-2021-04-22 --profile minimal && \
+# "alias" pinned nightly-2021-04-22 toolchain as nightly
+	ln -s /usr/local/rustup/toolchains/nightly-2021-04-22-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \


### PR DESCRIPTION
As requested by @bkchr. After this merge and consequent `paritytech/ci-linux:production` build:
* Rust stable will be on `1.52.1`
* Rust nightly will be on `2021-04-22`
* `nightly-2021-04-22` toolchain will be symlinked as `nightly` toolchain for seamless interoperability (or do we want to change `+nightly` to `+nightly-2021-04-22` in all relevant CI jobs?)

By the way, is there any other way to alias specific nightlies as "generic" nightly? `ln -s` looks like a hack and I wasn't able to find any info that symlinking toolchains like this is some kind of a proper practice.