### PR TITLE
Bump nightly to 2021-04-23 for `paritytech/ci-linux`

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -27,9 +27,9 @@ RUN set -eux && \
 # install `rust-src` component for ui test
 	rustup component add rust-src && \
 # install specific Rust nightly, default is stable, use minimum components
-	rustup toolchain install nightly-2021-04-22 --profile minimal && \
-# "alias" pinned nightly-2021-04-22 toolchain as nightly
-	ln -s /usr/local/rustup/toolchains/nightly-2021-04-22-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+	rustup toolchain install nightly-2021-04-23 --profile minimal && \
+# "alias" pinned nightly-2021-04-23 toolchain as nightly
+	ln -s /usr/local/rustup/toolchains/nightly-2021-04-23-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \


### PR DESCRIPTION
Missed one day here with my previous nightly pinning.

`paritytech/ci-linux:9a44d4ec-20210423` (`paritytech/ci-linux:production` before introducing Rust stable `1.52.1`) had nightly `7f4afdf02 2021-04-22`, not `b84932674 2021-04-21`, what I've pinned before.

This PR corrects that. Will rebuild `paritytech/ci-linux:production` after the merge.