### PR TITLE
bump diener in ci-linux image

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -35,7 +35,7 @@ RUN set -eux && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
 # install cargo tools
 	cargo install cargo-audit cargo-web wasm-pack cargo-deny mdbook && \
-	cargo install --version 0.3.2 diener && \
+	cargo install --version 0.3.3 diener && \
 # wasm-bindgen-cli version should match the one pinned in substrate
 # https://github.com/paritytech/substrate/blob/master/bin/node/browser-testing/Cargo.toml#L15
 	cargo install --version 0.2.73 wasm-bindgen-cli && \

--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -35,7 +35,7 @@ RUN set -eux && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
 # install cargo tools
 	cargo install cargo-audit cargo-web wasm-pack cargo-deny mdbook && \
-	cargo install --version 0.3.3 diener && \
+	cargo install --version 0.4.0 diener && \
 # wasm-bindgen-cli version should match the one pinned in substrate
 # https://github.com/paritytech/substrate/blob/master/bin/node/browser-testing/Cargo.toml#L15
 	cargo install --version 0.2.73 wasm-bindgen-cli && \


### PR DESCRIPTION
Due to changes in companion building in https://github.com/paritytech/substrate/pull/9010 - I need the ability to bump beefy using `diener`, which I added in `v0.4.0`. 