### PR TITLE
dockerfile: llvm-tools-preview

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -65,7 +65,7 @@ RUN	set -eux; \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly --target wasm32-unknown-unknown \
-		--profile minimal --component rustfmt clippy miri rust-src && \
+		--profile minimal --component rustfmt clippy miri rust-src llvm-tools-preview && \
 	rustup default nightly && \
 # We require `xargo` so that `miri` runs properly
 # We require `grcov` for coverage reporting and `rust-covfix` to improve it.

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -9,7 +9,8 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/ink-ci-linux" \
 	io.parity.image.description="Inherits from docker.io/paritytech/base-ci. \
-rust nightly, clippy, rustfmt, miri, rust-src grcov, rust-covfix, cargo-contract, xargo, binaryen" \
+rust nightly, clippy, rustfmt, miri, rust-src grcov, rust-covfix, llvm-tools-preview, \
+cargo-contract, xargo, binaryen, parallel, codecov" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/ink-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\

--- a/dockerfiles/ink-ci-linux/README.md
+++ b/dockerfiles/ink-ci-linux/README.md
@@ -43,6 +43,7 @@ We always use the [latest possible](https://rust-lang.github.io/rustup-component
 - `xargo`: Required so that `miri` runs properly.
 - `cargo-spellcheck`: Required for the CI to do automated spell-checking.
 - `wasm32-unknown-unknown`: The toolchain to compile Rust codebases for Wasm.
+- `llvm-tools-preview`: or MIR source-based Rust coverage instrumentation.
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/ink-ci-linux) for the registry.
 


### PR DESCRIPTION
adds `llvm-tools-preview` component to ink CI image, to the nightly toolchain. It's needed for MIR source-based Rust coverage instrumentation,