### PR TITLE
Install `rustfmt` for stable

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -25,7 +25,7 @@ RUN set -eux && \
 	apt-get install -y --no-install-recommends \
 		chromium-driver && \
 # install `rust-src` component for ui test
-	rustup component add rust-src && \
+	rustup component add rust-src rustfmt && \
 # install specific Rust nightly, default is stable, use minimum components
 	rustup toolchain install nightly-2021-06-29 --profile minimal --component rustfmt && \
 # "alias" pinned nightly-2021-06-29 toolchain as nightly


### PR DESCRIPTION
We are using `stable` for `canvas-node` and want to include `rustfmt` there.

CI fails currently with this:
```
$ cargo fmt --verbose --all -- --check
error: 'cargo-fmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'
To install, run `rustup component add rustfmt`
```
https://gitlab.parity.io/parity/canvas-node/-/jobs/1049080