### PR TITLE
TODO is fixed and now sccache is installed from crates

### DIFF
--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -46,10 +46,7 @@ RUN set -eux; \
   	rm rustup-init; \
   	chmod -R a+w ${RUSTUP_HOME} ${CARGO_HOME}; \
 # install sccache
-	# cargo install sccache --features redis; \
-	# FIXME: TEMPORARY OVERRIDE due to the sccache issue
-	# https://github.com/mozilla/sccache/issues/663
-	cargo install --git https://github.com/mozilla/sccache  --rev 6628e1f70db3d583cb5e79210603ad878de3d315 --features redis; \
+	cargo install sccache --features redis; \
 # versions
 	rustup show; \
 	cargo --version; \


### PR DESCRIPTION
The issue that was blocking the installation from the crates is resolved.
Issue in question is this https://github.com/mozilla/sccache/issues/663

Signed-off-by: Daniel Maricic <daniel@woss.io>