### PR TITLE
Explicitly bump nightly for `ci-linux`

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -27,9 +27,9 @@ RUN set -eux && \
 # install `rust-src` component for ui test
 	rustup component add rust-src && \
 # install specific Rust nightly, default is stable, use minimum components
-	rustup toolchain install nightly-2021-06-29 --profile minimal --component rustfmt && \
-# "alias" pinned nightly-2021-06-29 toolchain as nightly
-	ln -s /usr/local/rustup/toolchains/nightly-2021-06-29-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+	rustup toolchain install nightly-2021-08-24 --profile minimal --component rustfmt && \
+# "alias" pinned nightly-2021-08-24 toolchain as nightly
+	ln -s /usr/local/rustup/toolchains/nightly-2021-08-24-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \


### PR DESCRIPTION
`stable` toolchain will be bumped to `1.54.0` implicitly.