### PR TITLE
Migrate `canvas-node` to `substrate-contracts-node`

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -10,7 +10,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci-linux:latest. \
 llvm-dev, clang, zlib1g-dev, npm, yarn, wabt, binaryen. \
-rust nightly, rustfmt, clippy, rust-src, solang, canvas-node" \
+rust nightly, rustfmt, clippy, rust-src, solang, substrate-contracts-node" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -49,16 +49,16 @@ RUN set -eux; \
 	cargo install cargo-contract && \
 # tried v0.1.5 and the latest master - both fail with https://github.com/hyperledger-labs/solang/issues/314
 	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.2 && \
-# download the latest canvas-node binary
-	curl -L "https://gitlab.parity.io/parity/canvas-node/-/jobs/artifacts/master/raw/artifacts/canvas-linux/canvas?job=build-linux" \
-		-o /usr/local/cargo/bin/canvas && \
-	chmod +x /usr/local/cargo/bin/canvas && \
+# download the latest `substrate-contracts-node` binary
+	curl -L "https://gitlab.parity.io/parity/substrate-contracts-node/-/jobs/artifacts/master/raw/artifacts/substrate-contracts-node-linux/substrate-contracts-node?job=build-linux" \
+		-o /usr/local/cargo/bin/substrate-contracts-node && \
+	chmod +x /usr/local/cargo/bin/substrate-contracts-node && \
 # versions
 	yarn --version && \
 	rustup show && \
 	cargo --version && \
 	solang --version && \
-	canvas --version && \
+	substrate-contracts-node --version && \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -42,7 +42,7 @@ We always try to use the [latest possible](https://rust-lang.github.io/rustup-co
 - `cargo-contract`
 - `pwasm-utils-cli`
 - `solang`
-- `canvas-node`
+- `substrate-contracts-node`
 - `wasm32-unknown-unknown`: The toolchain to compile Rust codebases for Wasm.
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/contracts-ci-linux) for the registry.

--- a/dockerfiles/ink-waterfall-ci/Dockerfile
+++ b/dockerfiles/ink-waterfall-ci/Dockerfile
@@ -48,31 +48,31 @@ RUN	set -eux; \
 # `--locked` ensures the project's `Cargo.lock` is used.
 	cargo install --git https://github.com/paritytech/cargo-contract \
 		--locked --branch master --force && \
-# `canvas-node` is a Substrate chain with smart contract functionality.
+# `substrate-contracts-node` is a Substrate chain with smart contract functionality.
 # `--locked` ensures the project's `Cargo.lock` is used.
-	cargo install --git https://github.com/paritytech/canvas-node.git \
-		--locked --branch master && \
-# We additionally install the `canvas-node` as `canvas-rand-extension`.
-# This installation though is a modified `canvas-node`, so that ink!'s
+	cargo install --git https://github.com/paritytech/substrate-contracts-node.git \
+		--locked --branch main && \
+# We additionally install the `substrate-contracts-node` as `substrate-contracts-rand-extension`.
+# This installation though is a modified `substrate-contracts-node`, so that ink!'s
 # `rand-extension` chain extension example is included in the runtime.
 # This enables us to test in the waterfall that the `rand-extension`
 # integration with Substrate still works.
-	git clone --depth 1 https://github.com/paritytech/canvas-node.git && \
+	git clone --depth 1 https://github.com/paritytech/substrate-contracts-node.git && \
 	curl -s https://raw.githubusercontent.com/paritytech/ink/master/examples/rand-extension/runtime/chain-extension-example.rs \
-		>> canvas-node/runtime/src/lib.rs && \
-	sed -i 's/type ChainExtension = ();/type ChainExtension = FetchRandomExtension;/g' canvas-node/runtime/src/lib.rs && \
-	sed -i 's/name = "canvas"/name = "canvas-rand-extension"/g' canvas-node/node/Cargo.toml && \
-	cargo install --locked --path canvas-node/node/ && \
+		>> substrate-contracts-node/runtime/src/lib.rs && \
+	sed -i 's/type ChainExtension = ();/type ChainExtension = FetchRandomExtension;/g' substrate-contracts-node/runtime/src/lib.rs && \
+	sed -i 's/name = "substrate-contracts"/name = "substrate-contracts-rand-extension"/g' substrate-contracts-node/node/Cargo.toml && \
+	cargo install --locked --path substrate-contracts-node/node/ && \
 # versions
 	rustup show && \
 	cargo --version && \
 	cargo-contract --version && \
-	canvas --version && \
-	canvas-rand-extension --version && \
+	substrate-contracts-node --version && \
+	substrate-contracts-rand-extension --version && \
 # Clean up and remove compilation artifacts that a cargo install creates (>250M).
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
-# Clean up artifacts of `canvas-rand-extension` installation
-	rm -rf canvas-node/ && \
+# Clean up artifacts of `substrate-contracts-rand-extension` installation
+	rm -rf substrate-contracts-node/ && \
 # apt clean up
 	apt-get autoremove -y && \
 	apt-get clean && \

--- a/dockerfiles/ink-waterfall-ci/README.md
+++ b/dockerfiles/ink-waterfall-ci/README.md
@@ -2,7 +2,7 @@
 
 Docker image based on our base CI image `<ink-ci-linux:production>`.
 
-Used to build and run end-to-end tests for ink!, `cargo-contract`, `canvas-node` and `canvas-ui`.
+Used to build and run end-to-end tests for ink!, `cargo-contract`, `substrate-contracts-node` and `canvas-ui`.
 
 ## Dependencies and Tools
 
@@ -31,7 +31,7 @@ We always use the [latest possible](https://rust-lang.github.io/rustup-component
 **Rust tools & toolchains:**
 
 - `cargo-contract`: Required to build ink! Wasm smart contracts.
-- `canvas-node`: Required to run a Substrate chain for smart contracts.
+- `substrate-contracts-node`: Required to run a Substrate chain for smart contracts.
 - `wasm32-unknown-unknown`: The toolchain to compile Rust codebases for Wasm.
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/ink-waterfall-ci) for the registry.


### PR DESCRIPTION
We have migrated the `canvas-node` from a standalone node to a parachain setup. 

The former standalone node can now be found at https://github.com/paritytech/substrate-contracts-node.

The Docker image build will currently fail due to https://github.com/paritytech/ci_cd/issues/189. But the CI's for projects which use `canvas-node` are currently failing anyway, since the parachain setup is not suited for them.