### PR TITLE
dockerfiles: update pinned nightly to 2021-09-13

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -24,9 +24,9 @@ RUN set -eux && \
 # install `rust-src` component for ui test
 	rustup component add rust-src && \
 # install specific Rust nightly, default is stable, use minimum components
-	rustup toolchain install nightly-2021-08-24 --profile minimal --component rustfmt && \
-# "alias" pinned nightly-2021-08-24 toolchain as nightly
-	ln -s /usr/local/rustup/toolchains/nightly-2021-08-24-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+	rustup toolchain install nightly-2021-09-13 --profile minimal --component rustfmt && \
+# "alias" pinned nightly-2021-09-13 toolchain as nightly
+	ln -s /usr/local/rustup/toolchains/nightly-2021-09-13-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 # install wasm toolchain
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \


### PR DESCRIPTION
It's used in https://github.com/paritytech/polkadot/pull/3807 and https://github.com/paritytech/substrate/pull/9637 so if they are green, this may be merged.