### PR TITLE
Use latest `binaryen` release which contains a Linux binary

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -29,9 +29,12 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		zlib1g-dev npm wabt llvm-dev && \
 	npm install --ignore-scripts -g yarn && \
-# binaryen is needed by cargo-contract for optimizing Wasm files
-# we fetch the latest version number from the GitHub API and use that release
-	curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases/latest | \
+# `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
+# We fetch the latest release which contains a Linux binary. There is
+# currently an issue with not all releases containing a Linux binary
+# (https://github.com/WebAssembly/binaryen/issues/4148). Once that one
+# is fixed we can always use the latest release again.
+	curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases | \
 		egrep --only-matching 'https://github.com/WebAssembly/binaryen/releases/download/version_[0-9]+/binaryen-version_[0-9]+-x86_64-linux.tar.gz' | \
 		head -n1 | \
 		xargs curl -L -O && \

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -39,9 +39,12 @@ RUN	set -eux; \
 	chmod +x codecov && \
 	mv codecov /usr/local/bin/codecov && \
 	rm -f codecov.SHA256SUM codecov.SHA256SUM.sig && \
-# binaryen is needed by cargo-contract for optimizing Wasm files
-# we fetch the latest version number from the GitHub API and use that release
-	curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases/latest | \
+# `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
+# We fetch the latest release which contains a Linux binary. There is
+# currently an issue with not all releases containing a Linux binary
+# (https://github.com/WebAssembly/binaryen/issues/4148). Once that one
+# is fixed we can always use the latest release again.
+	curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases | \
 		egrep --only-matching 'https://github.com/WebAssembly/binaryen/releases/download/version_[0-9]+/binaryen-version_[0-9]+-x86_64-linux.tar.gz' | \
 		head -n1 | \
 		xargs curl -L -O && \


### PR DESCRIPTION
The ink! CI's fail currently because the latest `binaryen` release does not contain a Linux binary (see the linked issue).

This PR fixes this by falling back to the latest release *with a Linux binary*.