### PR TITLE
Increase pipelines resilience against accidental failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,12 @@ variables:                         &default-vars
 
 default:
   cache:                           {}
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - unknown_failure
+      - api_failure
 
 .build:                            &docker_build
   stage:                           build


### PR DESCRIPTION
This PR adds pipeline functionality to retry CI jobs twice in case if it failed due to following reasons:
```yml
      - runner_system_failure
      - unknown_failure
      - api_failure
 ```
It will increase pipelines resilience against accidental failures like network timeouts etc.