### PR TITLE
cachepot-ci: Add bubblewrap for dist compiles/tests

### DIFF
--- a/dockerfiles/cachepot-ci/Dockerfile
+++ b/dockerfiles/cachepot-ci/Dockerfile
@@ -37,7 +37,7 @@ RUN set -eux && \
 	apt-get install -y --no-install-recommends \
 		linux-headers-5.8.0-29 gcc binutils coreutils gdbserver \
 		libxcb-shape0-dev libxcb-xfixes0-dev \
-        zlib1g-dev librust-zip+deflate-miniz-dev gnupg2 && \
+        zlib1g-dev librust-zip+deflate-miniz-dev gnupg2 bubblewrap && \
 # setup nvcc
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub | apt-key add - && \
     echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /" > /etc/apt/sources.list.d/cuda.list && \


### PR DESCRIPTION
Refs paritytech/cachepot#128 paritytech/cachepot#114

Otherwise we can't run sandboxed builds in our dist test suite, see https://gitlab.parity.io/parity/cachepot/-/jobs/1291693#L2738 for example

cc @drahnr 