### PR TITLE
Add benchmarks image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -140,6 +140,11 @@ tools:
   script:
     - *push_to_docker_hub
 
+benchmarks:
+  <<:                              *docker_build
+  script:
+    - *push_to_docker_hub
+
 query-exporter:
   <<:                              *docker_build
   script:

--- a/dockerfiles/benchmarks/.gitignore
+++ b/dockerfiles/benchmarks/.gitignore
@@ -1,0 +1,2 @@
+output.txt
+output_redacted.txt

--- a/dockerfiles/benchmarks/Dockerfile
+++ b/dockerfiles/benchmarks/Dockerfile
@@ -1,0 +1,35 @@
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+ARG REGISTRY_PATH=docker.io/paritytech
+
+FROM docker.io/library/python:slim
+
+# metadata
+LABEL summary="Image for benchmarks" \
+	name="${REGISTRY_PATH}/benchmarks" \
+	maintainer="devops-team@parity.io" \
+	version="1.0" \
+	description="Image to push benchmarks and evaluate them" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/benchmarks/Dockerfile" \
+	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/benchmarks/README.md" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}"
+
+COPY check_bench_result.py /usr/local/bin/check_bench_result
+COPY push_bench_results.sh /usr/local/bin/push_bench_results
+
+RUN groupadd -g 10000 nonroot; \
+    useradd -u 10000 -g 10000 -s /bin/bash -m nonroot; \
+    mkdir /nonroot;\
+    chown nonroot. /nonroot
+
+USER nonroot:nonroot
+
+WORKDIR /nonroot
+
+COPY requirements.txt /tmp/requirements.txt
+
+RUN pip install -r /tmp/requirements.txt

--- a/dockerfiles/benchmarks/Dockerfile
+++ b/dockerfiles/benchmarks/Dockerfile
@@ -18,8 +18,8 @@ dockerfiles/benchmarks/README.md" \
 	io.parity.image.revision="${VCS_REF}" \
 	io.parity.image.created="${BUILD_DATE}"
 
-COPY check_bench_result.py /usr/local/bin/check_bench_result
-COPY push_bench_results.sh /usr/local/bin/push_bench_results
+COPY benchmarks/check_bench_result.py /usr/local/bin/check_bench_result
+COPY benchmarks/push_bench_results.sh /usr/local/bin/push_bench_results
 
 RUN groupadd -g 10000 nonroot; \
     useradd -u 10000 -g 10000 -s /bin/bash -m nonroot; \

--- a/dockerfiles/benchmarks/README.md
+++ b/dockerfiles/benchmarks/README.md
@@ -1,0 +1,43 @@
+Docker image to push and check benchmark results
+
+## check_bench_result.py
+
+The script takes an output file of `carg bench`, compares current result with the 
+latest result and creates a github issue if the threshold is exceeded.
+
+ci example:
+
+```yml
+.vault-secrets:                    &vault-secrets
+  secrets:
+    GITHUB_TOKEN:
+      vault:                       cicd/gitlab/parity/GITHUB_TOKEN@kv
+      file:                        false
+
+check_bench:
+  stage:                           check-result
+  image:                           paritytech/benchmarks:latest
+  variables:
+    PROMETHEUS_URL:                "http://vm-longterm.parity-build.parity.io"
+    TRESHOLD:                      20
+  <<:                              *vault-secrets
+  #get artifacts with output.txt
+  needs:
+    - job:                         benchmarks
+      artifacts:                   true
+  script:
+    - check_bench_result artifacts/output.txt
+
+```
+
+Local run example:
+
+```bash
+export GITHUB_TOKEN=<token>        # Github token with repo permissions
+export CI_PROJECT_NAME=<project>   # Github project
+export GITHUB_ORG=<org>            # Optional. Github organisation, default = paritytech
+export CI_COMMIT_SHA=<current_sha> # Latest commit sha in master
+export PROMETHEUS_URL=<url>        # Prometheus/VictoriaMetrics URL
+export TRESHOLD=20                 # Optional. Threshold to create github issue, default = 20
+python3 check_bench_result.py output.txt
+```

--- a/dockerfiles/benchmarks/check_bench_result.py
+++ b/dockerfiles/benchmarks/check_bench_result.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+The script compares current benchmark result with the previous
+and creates an issue in GitHub if it exceeds the threshold
+Usage: check_bench_result.py <file with benchmark results> <github_org>
+Example: check_bench_result.py output.txt
+"""
+
+import os
+import sys
+from prometheus_api_client import PrometheusConnect
+from github import Github
+
+try:
+    github_org = os.environ['GITHUB_ORG']
+except KeyError:
+    github_org = "paritytech"
+
+try:
+    results_file = sys.argv[1]
+    github_token = os.environ['GITHUB_TOKEN']
+    github_repo = os.environ['CI_PROJECT_NAME']
+    github_repo_full = f"{github_org}/{github_repo}"
+    current_sha = os.environ['CI_COMMIT_SHA']
+    prometheus_url = os.environ['PROMETHEUS_URL']
+except KeyError as error:
+    print(f"{error} not found in environment variables")
+    sys.exit(1)
+except IndexError:
+    print("Please specify file with benchmark results and github_org")
+    print("Usage:",sys.argv[0],"<file with benchmark results>")
+    sys.exit(1)
+
+try:
+    treshold = os.environ['THRESHOLD']
+except KeyError:
+    treshold = 20
+
+prometheus_client = PrometheusConnect(url=prometheus_url, disable_ssl=True)
+github_client = Github(github_token)
+
+def benchmark_last(project,benchmark):
+    """Get latest benchmark result from Victoria Metrics"""
+    query = f"last_over_time(parity_benchmark_common_result_ns{{project=\"{project}\",benchmark=\"{benchmark}\"}}[1y])"
+    query_result = prometheus_client.custom_query(query=query)
+    last_benchmark_result = int(query_result[0]['value'][1])
+    return last_benchmark_result
+
+def create_github_issue(benchmarks_list,github_org_repo):
+    """Create github issue with list of benchmarks"""
+    # repo = github_client.get_repo(github_org_repo)
+    repo = github_client.get_repo("tripleightech/gl-gh-test")
+    last_sha = repo.get_commits()[1].sha
+    commit_url = f"https://github.com/{github_repo_full}/commit/"
+    benchmarks_mstring = "\n".join(benchmarks_list)
+    issue_text = f"""
+## Benchmarks have regressions
+
+Threshold: {treshold}%
+
+These benchmarks have regressions:
+
+| Benchmark name | Previous result [{last_sha[:8]}]({commit_url}{last_sha}) | Current result [{current_sha[:8]}]({commit_url}{current_sha}) | Ratio |
+|---|---|---|---|
+{benchmarks_mstring}
+                 """
+    github_issue = repo.create_issue(title="[benchmarks] Regression detected", body=issue_text)
+    return github_issue
+
+if __name__ == "__main__":
+    output_file = open(results_file, 'r')
+    bench_results = output_file.readlines()
+    output_file.close()
+    benchmarks_with_regression = []
+    for result in bench_results:
+        if not "test" in result:
+            continue
+        benchmark_name = result.split()[1]
+        benchmark_current_value = int(result.split()[4])
+        try:
+            benchmark_last_value = benchmark_last(github_repo,benchmark_name)
+        except IndexError:
+            print(benchmark_name,"doesn't have data, skipping")
+            continue
+        if benchmark_current_value > benchmark_last_value:
+            ratio = benchmark_current_value * 100 / benchmark_last_value
+            subt = round(abs(100 - ratio))
+            if subt > treshold:
+                regression = True
+                string_to_add = f"| {benchmark_name} | {benchmark_last_value} ns/iter | {benchmark_current_value} ns/iter | {subt}% |"
+                benchmarks_with_regression.append(string_to_add)
+            else:
+                regression = False
+    if len(benchmarks_with_regression) > 0:
+        print("Regression found, creating GitHub issue")
+        issue = create_github_issue(benchmarks_with_regression,github_repo_full)
+        print(issue)
+    else:
+        print("No regressions")

--- a/dockerfiles/benchmarks/check_bench_result.py
+++ b/dockerfiles/benchmarks/check_bench_result.py
@@ -116,3 +116,4 @@ if __name__ == "__main__":
         print(issue)
     else:
         print("No regressions")
+

--- a/dockerfiles/benchmarks/check_bench_result.py
+++ b/dockerfiles/benchmarks/check_bench_result.py
@@ -48,8 +48,7 @@ def benchmark_last(project,benchmark):
 
 def create_github_issue(benchmarks_list,github_org_repo):
     """Create github issue with list of benchmarks"""
-    # repo = github_client.get_repo(github_org_repo)
-    repo = github_client.get_repo("tripleightech/gl-gh-test")
+    repo = github_client.get_repo(github_org_repo)
     last_sha = repo.get_commits()[1].sha
     commit_url = f"https://github.com/{github_repo_full}/commit/"
     benchmarks_mstring = "\n".join(benchmarks_list)

--- a/dockerfiles/benchmarks/check_bench_result.py
+++ b/dockerfiles/benchmarks/check_bench_result.py
@@ -32,18 +32,24 @@ except IndexError:
     sys.exit(1)
 
 try:
-    treshold = os.environ['THRESHOLD']
+    threshold = os.environ['THRESHOLD']
 except KeyError:
-    treshold = 20
+    threshold = 20
 
 prometheus_client = PrometheusConnect(url=prometheus_url, disable_ssl=True)
 github_client = Github(github_token)
 
 def benchmark_last(project,benchmark):
-    """Get latest benchmark result from Victoria Metrics"""
+    """
+    Get latest benchmark result from Victoria Metrics
+    Returns "-1" if result not found
+    """
     query = f"last_over_time(parity_benchmark_common_result_ns{{project=\"{project}\",benchmark=\"{benchmark}\"}}[1y])"
     query_result = prometheus_client.custom_query(query=query)
-    last_benchmark_result = int(query_result[0]['value'][1])
+    if len(query_result) > 0:
+        last_benchmark_result = int(query_result[0]['value'][1])
+    else:
+        last_benchmark_result = -1
     return last_benchmark_result
 
 def create_github_issue(benchmarks_list,github_org_repo):
@@ -55,41 +61,55 @@ def create_github_issue(benchmarks_list,github_org_repo):
     issue_text = f"""
 ## Benchmarks have regressions
 
-Threshold: {treshold}%
+Threshold: {threshold}%
 
 These benchmarks have regressions:
 
-| Benchmark name | Previous result [{last_sha[:8]}]({commit_url}{last_sha}) | Current result [{current_sha[:8]}]({commit_url}{current_sha}) | Ratio |
+| Benchmark name | Previous result [{last_sha[:8]}]({commit_url}{last_sha}) (ns/iter) | Current result [{current_sha[:8]}]({commit_url}{current_sha}) (ns/iter) | Difference (%) |
 |---|---|---|---|
 {benchmarks_mstring}
                  """
     github_issue = repo.create_issue(title="[benchmarks] Regression detected", body=issue_text)
     return github_issue
 
+def get_name_value(line):
+    """Get benchmark name and result from a text line"""
+    name = line.split()[1]
+    value = int(line.split()[4])
+    return name,value
+
+def check_line_valid(line):
+    """
+    Check that line can be transformed to a list with 8 values
+    Expects line "test <benchmark_name_with_underscores> ... bench:  <bench_result> ns/iter (+/- <bench_result_difference_between_max_min>)"
+    """
+    if len(line.split()) != 8:
+        print("Data has wrong format")
+        sys.exit(1)
+    pass
+
+def difference_p(first,second):
+    """Calculate difference between 2 values in percent"""
+    return round(abs(first * 100 / second - 100))
+
 if __name__ == "__main__":
-    output_file = open(results_file, 'r')
-    bench_results = output_file.readlines()
-    output_file.close()
     benchmarks_with_regression = []
-    for result in bench_results:
-        if not "test" in result:
-            continue
-        benchmark_name = result.split()[1]
-        benchmark_current_value = int(result.split()[4])
-        try:
+    with open(results_file, 'r') as file_handle:
+        for result in file_handle:
+            # Skipping lines without benchmark results
+            if not "test" in result:
+                continue
+            check_line_valid(result)
+            benchmark_name,benchmark_current_value = get_name_value(result)
             benchmark_last_value = benchmark_last(github_repo,benchmark_name)
-        except IndexError:
-            print(benchmark_name,"doesn't have data, skipping")
-            continue
-        if benchmark_current_value > benchmark_last_value:
-            ratio = benchmark_current_value * 100 / benchmark_last_value
-            subt = round(abs(100 - ratio))
-            if subt > treshold:
-                regression = True
-                string_to_add = f"| {benchmark_name} | {benchmark_last_value} ns/iter | {benchmark_current_value} ns/iter | {subt}% |"
-                benchmarks_with_regression.append(string_to_add)
-            else:
-                regression = False
+            if benchmark_last_value == -1:
+                print(benchmark_name,"is new and doesn't have any data yet, skipping")
+                continue
+            if benchmark_current_value > benchmark_last_value:
+                diff = difference_p(benchmark_current_value,benchmark_last_value)
+                if diff > threshold:
+                    string_to_add = f"| {benchmark_name} | {benchmark_last_value} ns/iter | {benchmark_current_value} ns/iter | {diff}% |"
+                    benchmarks_with_regression.append(string_to_add)
     if len(benchmarks_with_regression) > 0:
         print("Regression found, creating GitHub issue")
         issue = create_github_issue(benchmarks_with_regression,github_repo_full)

--- a/dockerfiles/benchmarks/push_bench_results.sh
+++ b/dockerfiles/benchmarks/push_bench_results.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# The script takes output.txt, removes every line that doesn't have "test"
+# in it and pushes benchmark result to Victoria Metrics
+# Benchmark name should have underscores in the name instead of spaces (e.g. async/http_concurrent_round_trip/8)
+
+RESULT_FILE=$1
+CURRENT_DIR=$(pwd)
+
+if [ -z "$RESULT_FILE" ]
+then
+  RESULT_FILE="output.txt"
+fi
+
+cat $RESULT_FILE | grep test > $CURRENT_DIR/output_redacted.txt
+
+INPUT="output_redacted.txt"
+
+while IFS= read -r line
+do
+  BENCH_NAME=$(echo $line | cut -f 2 -d ' ')
+  BENCH_RESULT=$(echo $line | cut -f 5 -d ' ')
+  # send metric with common results
+  curl -d 'parity_benchmark_common_result_ns{project="'${CI_PROJECT_NAME}'",benchmark="'$BENCH_NAME'"} '$BENCH_RESULT'' \
+    -X POST "${PROMETHEUS_URL}/api/v1/import/prometheus"
+  # send metric with detailed results
+  curl -d 'parity_benchmark_specific_result_ns{project="'${CI_PROJECT_NAME}'",benchmark="'$BENCH_NAME'",commit="'${CI_COMMIT_SHORT_SHA}'",cirunner="'${RUNNER_NAME}'"} '$BENCH_RESULT'' \
+    -X POST "${PROMETHEUS_URL}/api/v1/import/prometheus"
+done < "$INPUT"

--- a/dockerfiles/benchmarks/requirements.txt
+++ b/dockerfiles/benchmarks/requirements.txt
@@ -1,0 +1,2 @@
+prometheus_api_client==0.4.2
+PyGithub==1.55


### PR DESCRIPTION
This PR adds `paritytech/benchmarks` image.

In the issue https://github.com/paritytech/ci_cd/issues/275 was a request to check benchmarks and create a github issue if they exceeds threshold 20%

I created a script that does that but also decided to put this into a docker image so we can reuse it in other projects