### PR TITLE
Add python and the kubernetes-python lib to the helm3 image

### DIFF
--- a/dockerfiles/kubetools/helm3.Dockerfile
+++ b/dockerfiles/kubetools/helm3.Dockerfile
@@ -21,7 +21,9 @@ dockerfiles/kubetools/README.md" \
     io.parity.image.created="${BUILD_DATE}"
 
 RUN apk add --no-cache \
-        ca-certificates git jq make curl gettext bash shadow && \
+        ca-certificates git jq make curl gettext bash shadow python3 py3-pip && \
+    pip3 install --no-cache --upgrade pip kubernetes && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
     # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/
     curl -L "https://dl.k8s.io/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl" \
         -o /usr/local/bin/kubectl && \


### PR DESCRIPTION
This is required for running custom Python scripts in Kubernetes CI jobs.