### PR TITLE
Revert me: Set fixed Rust nighly version

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -42,9 +42,9 @@ RUN set -eux; \
 	rm -rf binaryen-*/ && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
-	rustup toolchain install nightly --target wasm32-unknown-unknown \
+	rustup toolchain install nightly-2022-01-20 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy rust-src && \
-	rustup default nightly && \
+	rustup default nightly-2022-01-20 && \
 	cargo install pwasm-utils-cli --bin wasm-prune && \
 	cargo install cargo-dylint dylint-link && \
 	cargo install cargo-contract && \


### PR DESCRIPTION
I've added some `dylint` stuff to the `cargo-contract` CI docker image in https://github.com/paritytech/scripts/pull/382. The docker image can't be build currently though: https://gitlab.parity.io/parity/cargo-contract/-/jobs/1376793.

This is due to an ICE in the nightly version of the Rust compiler (https://github.com/rust-lang/rust/issues/93788). Since I need those `dylint` tools now-ish, I would like to temporarily set a fixed Rust nightly version. We can revert this PR once the ICE is fixed.

Let's not go into a discussion of setting a fixed toolchain version now.