### PR TITLE
Filter empty new lines in `--version` output

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -59,7 +59,7 @@ RUN set -eux; \
 	rustup show && \
 	cargo --version && \
 	solang --version && \
-	substrate-contracts-node --version && \
+	echo $( substrate-contracts-node --version | awk 'NF' ) && \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \

--- a/dockerfiles/ink-waterfall-ci/Dockerfile
+++ b/dockerfiles/ink-waterfall-ci/Dockerfile
@@ -74,7 +74,7 @@ RUN	set -eux; \
 	rustup show && \
 	cargo --version && \
 	cargo-contract --version && \
-	substrate-contracts-node --version && \
+	echo $( substrate-contracts-node --version | awk 'NF' ) && \
 	substrate-contracts-node-rand-extension --version && \
 # Clean up and remove compilation artifacts that a cargo install creates (>250M).
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \


### PR DESCRIPTION
Building those containers currently fails: https://gitlab.parity.io/parity/infrastructure/scripts/-/jobs/1433766.

```
+ substrate-contracts-node --version
/usr/local/cargo/bin/substrate-contracts-node: 2: Syntax error: newline unexpected
subprocess exited with status 2
```

This is due to the recent `clap` switch/upgrade in Substrate. I've added a commit which filters empty lines from the `--version` output.