### PR TITLE
Add `estuary` to `contracts-ci-linux`

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -54,12 +54,16 @@ RUN set -eux; \
 	curl -L "https://gitlab.parity.io/parity/substrate-contracts-node/-/jobs/artifacts/master/raw/artifacts/substrate-contracts-node-linux/substrate-contracts-node?job=build-linux" \
 		-o /usr/local/cargo/bin/substrate-contracts-node && \
 	chmod +x /usr/local/cargo/bin/substrate-contracts-node && \
+# We use `estuary` as a lightweight cargo registry in the CI to test if
+# publishing `cargo-contract` to it and installing it from there works.
+	cargo install --git https://github.com/onelson/estuary.git --force && \
 # versions
 	yarn --version && \
 	rustup show && \
 	cargo --version && \
 	solang --version && \
 	echo $( substrate-contracts-node --version | awk 'NF' ) && \
+	estuary --version && \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \

--- a/dockerfiles/contracts-ci-linux/README.md
+++ b/dockerfiles/contracts-ci-linux/README.md
@@ -45,6 +45,7 @@ We always try to use the [latest possible](https://rust-lang.github.io/rustup-co
 - `solang`
 - `substrate-contracts-node`
 - `wasm32-unknown-unknown`: The toolchain to compile Rust codebases for Wasm.
+- `estuary`: Lightweight cargo registry to test if publishing/installing works.
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/contracts-ci-linux) for the registry.
 


### PR DESCRIPTION
Yesterday I wanted to publish a new release of `cargo-contract` (https://github.com/paritytech/cargo-contract/pull/461), but while doing so I noticed that the publishing failed due to some issues which we notice find before (e.g. missing `include`'s in the `Cargo.toml` and directories no longer being found due to how `CARGO_MANIFEST_DIR` changes when publishing).

Those issues only surface when actually going through the publish process. Some parts of it can be mocked with `cargo package`, but that only covers part of the publishing process.

`cargo-contract` has a bit of an elaborate `build.rs` now and I would like to have a CI stage for this project which spawns a lightweight local registry, publishes to it, installs from it, and does some smoke testing with the installed binary. I want to use `estuary` for that, got it running locally and seems to work fine.