### PR TITLE
Install `cargo-dylint` and `dylint-link` in `ink-ci-linux`

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -50,6 +50,8 @@ RUN	set -eux; \
 	chmod +x binaryen-*/bin/wasm-opt && \
 	mv binaryen-*/bin/wasm-opt /usr/local/bin/ && \
 	rm -rf binaryen-*/ && \
+# `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
+	cargo install cargo-dylint dylint-link && \
 # The supported Rust nightly version must support the following components
 # to allow for a functioning CI pipeline:
 #

--- a/dockerfiles/ink-ci-linux/README.md
+++ b/dockerfiles/ink-ci-linux/README.md
@@ -8,7 +8,8 @@ Used to build and test ink!.
 
 - `parallel`: for running commands in parallel, without overlapping output
 - `codecov`: to upload the test coverage results
-- `binaryen`: needed by cargo-contract for optimizing Wasm files
+- `binaryen`: needed by `cargo-contract` for optimizing Wasm files
+- `cargo-dylint` and `dylint-link`: needed by `cargo-contract` for running lints
 
 **Inherited from `<base-ci:latest>`**
 


### PR DESCRIPTION
Only noticed now (after the `cargo-contract` 0.18.0 release today) that those are missing in the ink! CI.