### PR TITLE
test: gitspiegl mirrored repo triggered by external project

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -413,6 +413,17 @@ ink-ci-linux-test:
     branch:                        master
     strategy:                      depend
 
+contracts-ci-linux-test-gitspiegel:
+  stage:                           test
+  variables:
+    CI_IMAGE:                      "paritytech/contracts-ci-linux:staging"
+  rules:
+    - if: $IMAGE_NAME == "contracts-ci-linux"
+  trigger:
+    project:                       parity/mirrors/cargo-contract
+    branch:                        master
+    strategy:                      depend
+
 contracts-ci-linux-test:
   stage:                           test
   variables:


### PR DESCRIPTION
This PR has 2 purposes:

1. Test that a project mirrored with `gitspiegel` can be triggered by upstream project
2. Make it easy to compare pipelines of same project `gitlab native mirroring` VS  `gitpsigel mirrored `

Part of 
[Spring migration of wild mirrors #alpha. #350](https://github.com/paritytech/ci_cd/issues/350)