### PR TITLE
Add molecule docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,6 +125,11 @@ contracts-ci-linux:
     - *push_to_staging
     - *publish_as_latest_too
 
+debian10:
+  <<:                              *docker_build
+  script:
+    - *push_to_docker_hub
+
 bridges-ci:
   <<:                              *docker_build
   script:
@@ -156,6 +161,11 @@ query-exporter:
     - *push_to_docker_hub
 
 redis-exporter:
+  <<:                              *docker_build
+  script:
+    - *push_to_docker_hub
+
+molecule:
   <<:                              *docker_build
   script:
     - *push_to_docker_hub

--- a/dockerfiles/debian10/Dockerfile
+++ b/dockerfiles/debian10/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:buster
+
+# metadata
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+ARG REGISTRY_PATH=docker.io/paritytech
+LABEL io.parity.image.authors="devops-team@parity.io" \
+        io.parity.image.vendor="Parity Technologies" \
+        io.parity.image.title="${REGISTRY_PATH}/debian10" \
+        io.parity.image.description="ansible" \
+        io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/debian10/Dockerfile" \
+        io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/debian10/README.md" \
+        io.parity.image.revision="${VCS_REF}" \
+        io.parity.image.created="${BUILD_DATE}"
+
+
+ARG DEBIAN_FRONTEND=noninteractive
+# Install dependencies.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       sudo systemd systemd-sysv \
+       build-essential wget libffi-dev libssl-dev \
+       python3-pip python3-dev python3-setuptools python3-wheel python3-apt \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/lib/systemd/systemd"]

--- a/dockerfiles/debian10/README.md
+++ b/dockerfiles/debian10/README.md
@@ -1,0 +1,3 @@
+# Description
+This Debian 10 image is used in the ansible Molecule test as a base to apply roles. 
+The docker image should be close to default GCP or AWS images.

--- a/dockerfiles/molecule/Dockerfile
+++ b/dockerfiles/molecule/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.10
+
+# metadata
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+ARG REGISTRY_PATH=docker.io/paritytech
+LABEL io.parity.image.authors="devops-team@parity.io" \
+        io.parity.image.vendor="Parity Technologies" \
+        io.parity.image.title="${REGISTRY_PATH}/molecule" \
+        io.parity.image.description="ansible" \
+        io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/molecule/Dockerfile" \
+        io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/molecule/README.md" \
+        io.parity.image.revision="${VCS_REF}" \
+        io.parity.image.created="${BUILD_DATE}"
+
+RUN pip install --no-cache-dir  \
+    ansible \
+    ansible-lint==6.0.1 \
+    yamllint \
+    "molecule[docker]"==3.6.1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       docker.io \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
+
+# Do not switch to nonroot user, molecule have to connect to docker engine anyway.
+# nonroot will create a false fealing of security.

--- a/dockerfiles/molecule/README.md
+++ b/dockerfiles/molecule/README.md
@@ -1,0 +1,2 @@
+# Description
+Image with ansible and molecule. Used in GitLab CI to test ansible roles.


### PR DESCRIPTION
`molecule` and `debian10` images was added. This images will be used in ansible molecule CI. 
