### PR TITLE
Add simple initial docker image for `smart-bench`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,6 +119,11 @@ ink-waterfall-ci:
   script:
     - *push_to_docker_hub
 
+smart-bench-ci:
+  <<:                              *docker_build
+  script:
+    - *push_to_docker_hub
+
 contracts-ci-linux:
   <<:                              *docker_build
   script:

--- a/dockerfiles/smart-bench-ci/Dockerfile
+++ b/dockerfiles/smart-bench-ci/Dockerfile
@@ -1,0 +1,49 @@
+ARG VCS_REF=master
+ARG BUILD_DATE
+ARG REGISTRY_PATH=docker.io/paritytech
+
+# `production` tag is used here to base off the image that has already been tested against
+# the `ink` CI. This reduces the maintenance of fixing the same nightly stuff in both images.
+FROM ${REGISTRY_PATH}/ink-ci-linux:production
+
+# metadata
+LABEL io.parity.image.authors="devops-team@parity.io" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.title="${REGISTRY_PATH}/smart-bench-ci" \
+	io.parity.image.description="Inherits from docker.io/paritytech/ink-ci-linux." \
+	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/smart-bench-ci/Dockerfile" \
+	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/smart-bench-ci/README.md" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}"
+
+WORKDIR /builds
+
+ENV SHELL /bin/bash
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN	set -eux; \
+	apt-get -y update && \
+	apt-get install -y --no-install-recommends \
+# `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
+	cargo install cargo-dylint dylint-link && \
+# `cargo-contract` is needed for building those examples. Here it's
+# force-rewritten above the stable version from the parent image.
+# `--force` rewrites the stable version installed in the parent image.
+# `--locked` ensures the project's `Cargo.lock` is used.
+	cargo install --git https://github.com/paritytech/cargo-contract \
+		--locked --branch master --force && \
+# versions
+	rustup show && \
+	cargo --version && \
+	cargo-contract --version && \
+# Clean up and remove compilation artifacts that a cargo install creates (>250M).
+	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
+# apt clean up
+	apt-get autoremove -y && \
+	apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
+
+# TODO: https://gitlab.parity.io/parity/infrastructure/scripts/-/jobs/958687
+# USER nonroot:nonroot

--- a/dockerfiles/smart-bench-ci/README.md
+++ b/dockerfiles/smart-bench-ci/README.md
@@ -1,0 +1,47 @@
+# CI image for [`smart-bench`](https://github.com/paritytech/smart-bench/)
+
+Docker image based on our base CI image `<ink-ci-linux:production>`.
+
+Used to build and run benchmarks of smart contracts on a parachain.
+
+## Dependencies and Tools
+
+**Inherited from `<base-ci:latest>`**
+
+- `libssl-dev`
+- `lld`
+- `libclang-dev`
+- `make`
+- `cmake`
+- `git`
+- `pkg-config`
+- `curl`
+- `time`
+- `rhash`
+- `ca-certificates`
+
+**Rust versions:**
+
+We always use the [latest possible](https://rust-lang.github.io/rustup-components-history/) `nightly` version that supports our required `rustup` components:
+
+- `clippy`: The Rust linter.
+- `rust-src`: The Rust sources of the standard library.
+- `rustfmt`: The Rust code formatter.
+
+**Rust tools & toolchains:**
+
+- `cargo-contract`: Required to build ink! Wasm smart contracts.
+- `cargo-dylint` and `dylint-link`: Required to run `cargo-contract`.
+- `wasm32-unknown-unknown`: The toolchain to compile a Rust codebase for Wasm.
+
+[Click here](https://hub.docker.com/repository/docker/paritytech/smart-bench-ci) for the registry.
+
+## Usage
+
+```yaml
+test-ink:
+    stage: test
+        image: paritytech/smart-bench-ci:latest
+        script:
+            - cargo build ...
+```


### PR DESCRIPTION
Needed for https://github.com/paritytech/ci_cd/issues/357.

I copied the `ink-waterfall-ci` image and threw a lot of stuff out.