### PR TITLE
Install diener from paritytech repository

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -29,7 +29,8 @@ RUN set -eux && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
 	# install cargo tools
 	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck && \
-	cargo install --version 0.4.2 diener && \
+  # diener can be installed from crates.io when https://github.com/bkchr/diener/issues/15 is fixed
+	cargo install --git https://github.com/paritytech/diener --branch all-packages && \
 	# wasm-bindgen-cli version should match the one pinned in substrate
 	# https://github.com/paritytech/substrate/blob/master/bin/node/browser-testing/Cargo.toml#L15
 	cargo install --version 0.2.73 wasm-bindgen-cli && \


### PR DESCRIPTION
Alternative to https://github.com/paritytech/pipeline-scripts/pull/46/files#diff-df602127cd49392d5fb1da82c27351842395a47e788e0c6a77cf52d690ed1d2aR500 where instead of installing `diener` for every `check-dependent-*` job, we instead bake the binary into the image. That would be better than having to download and install it for each job.

Related to https://github.com/bkchr/diener/issues/15