### PR TITLE
CI: fix trivy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -388,9 +388,6 @@ container_scanning:
     entrypoint:                    [""]
   variables:
     GIT_STRATEGY:                  none
-    TRIVY_USERNAME:                "$CI_REGISTRY_USER"
-    TRIVY_PASSWORD:                "$CI_REGISTRY_PASSWORD"
-    TRIVY_AUTH_URL:                "$CI_REGISTRY"
     TRIVY_NO_PROGRESS:             "true"
     TRIVY_CACHE_DIR:               ".trivycache/"
     FULL_IMAGE_NAME:               $REGISTRY_PATH/$IMAGE_NAME:$IMAGE_TAG


### PR DESCRIPTION
Trivy is going to pull images from public registries, so no auth is needed. See https://gitlab.parity.io/parity/mirrors/scripts/-/jobs/1588328