### PR TITLE
ci-linux - add cargo-nextest to the image

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux && \
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
 	# install cargo tools
-	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck && \
+	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-nextest && \
 	cargo install --version 0.4.2 diener && \
 	# wasm-bindgen-cli version should match the one pinned in substrate
 	# https://github.com/paritytech/substrate/blob/master/bin/node/browser-testing/Cargo.toml#L15


### PR DESCRIPTION
PR adds cargo-nextest to the `ci-linux` image

Part of https://github.com/paritytech/ci_cd/issues/334