### PR TITLE
Update Dockerfile to match gitlab-ci context path

### DIFF
--- a/dockerfiles/ws-health-exporter/Dockerfile
+++ b/dockerfiles/ws-health-exporter/Dockerfile
@@ -17,7 +17,7 @@ dockerfiles/ws-health-exporter/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 RUN pip install --no-cache-dir prometheus-client websocket-client apscheduler flask
-COPY exporter.py .
+COPY ws-health-exporter/exporter.py .
 
 USER nobody:nogroup
 


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

Update Dockerfile to match gitlab-ci context path. It is set to `dockerfiles` directory which fails the build with the previous setup.