### PR TITLE
Remove `USER` directive from the `paritytech/cachepot-ci` image

### DIFF
--- a/dockerfiles/cachepot-ci/Dockerfile
+++ b/dockerfiles/cachepot-ci/Dockerfile
@@ -71,5 +71,4 @@ ENV	RUSTC_WRAPPER=sccache \
 # show backtraces
   	RUST_BACKTRACE=1
 
-USER nonroot:nonroot
 CMD ["bash", "-l"]


### PR DESCRIPTION
The `nonroot` user is left intact, so we can switch to it via `entrypoint: ['bash', '-c', 'exec su nonroot -c bash']` if required.