### PR TITLE
contracts-ci: remove solang

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -48,8 +48,7 @@ RUN set -eux; \
 	cargo install pwasm-utils-cli --bin wasm-prune && \
 	cargo install cargo-dylint dylint-link && \
 	cargo install cargo-contract && \
-# tried v0.1.5 and the latest master - both fail with https://github.com/hyperledger-labs/solang/issues/314
-	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.2 && \
+	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.12 && \
 # download the latest `substrate-contracts-node` binary
 	curl -L "https://gitlab.parity.io/parity/substrate-contracts-node/-/jobs/artifacts/master/raw/artifacts/substrate-contracts-node-linux/substrate-contracts-node?job=build-linux" \
 		-o /usr/local/cargo/bin/substrate-contracts-node && \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -10,7 +10,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci:latest. \
 llvm-dev, clang, zlib1g-dev, npm, yarn, wabt, binaryen. \
-rust nightly, rustfmt, clippy, rust-src, substrate-contracts-node" \
+rust nightly, rustfmt, clippy, rust-src, solang, substrate-contracts-node" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -48,6 +48,7 @@ RUN set -eux; \
 	cargo install pwasm-utils-cli --bin wasm-prune && \
 	cargo install cargo-dylint dylint-link && \
 	cargo install cargo-contract && \
+	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.12 && \
 # download the latest `substrate-contracts-node` binary
 	curl -L "https://gitlab.parity.io/parity/substrate-contracts-node/-/jobs/artifacts/master/raw/artifacts/substrate-contracts-node-linux/substrate-contracts-node?job=build-linux" \
 		-o /usr/local/cargo/bin/substrate-contracts-node && \
@@ -59,6 +60,7 @@ RUN set -eux; \
 	yarn --version && \
 	rustup show && \
 	cargo --version && \
+	solang --version && \
 	echo $( substrate-contracts-node --version | awk 'NF' ) && \
 	estuary --version && \
 # cargo clean up

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -10,7 +10,7 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.title="${REGISTRY_PATH}/contracts-ci-linux" \
 	io.parity.image.description="Inherits from base-ci:latest. \
 llvm-dev, clang, zlib1g-dev, npm, yarn, wabt, binaryen. \
-rust nightly, rustfmt, clippy, rust-src, solang, substrate-contracts-node" \
+rust nightly, rustfmt, clippy, rust-src, substrate-contracts-node" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/contracts-ci-linux/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -48,7 +48,6 @@ RUN set -eux; \
 	cargo install pwasm-utils-cli --bin wasm-prune && \
 	cargo install cargo-dylint dylint-link && \
 	cargo install cargo-contract && \
-	cargo install --git https://github.com/hyperledger-labs/solang --tag v0.1.12 && \
 # download the latest `substrate-contracts-node` binary
 	curl -L "https://gitlab.parity.io/parity/substrate-contracts-node/-/jobs/artifacts/master/raw/artifacts/substrate-contracts-node-linux/substrate-contracts-node?job=build-linux" \
 		-o /usr/local/cargo/bin/substrate-contracts-node && \
@@ -60,7 +59,6 @@ RUN set -eux; \
 	yarn --version && \
 	rustup show && \
 	cargo --version && \
-	solang --version && \
 	echo $( substrate-contracts-node --version | awk 'NF' ) && \
 	estuary --version && \
 # cargo clean up


### PR DESCRIPTION
Attempt to fix [broken docker build](https://gitlab.parity.io/parity/mirrors/scripts/-/jobs/1661549).

`cargo install` no longer works out of the box without (I think) a build of[ `llvm-project` ](https://github.com/hyperledger-labs/solang/blob/main/.github/Dockerfile#L11) which adds the `Driver.h` file to the path for the [linker include](https://github.com/hyperledger-labs/solang/blob/c046e64db8890d0db83d65cbfd2bb0918b7ffd1e/src/linker/linker.cpp#L2).

```
cargo:warning=src/linker/linker.cpp:2:10: fatal error: 'lld/Common/Driver.h' file not found
cargo:warning=#include "lld/Common/Driver.h"
```

A rudimentary [search](https://github.com/search?p=2&q=org%3Aparitytech+solang&type=Code) appears that this is not used anywhere currently by this image.

If this is required anywhere in CI, I suggest using the solang [docker](https://github.com/hyperledger-labs/solang/blob/main/Dockerfile) [image](https://github.com/hyperledger-labs/solang/pkgs/container/solang) directly: (https://github.com/hyperledger-labs/solang/pkgs/container/solang)

rel https://github.com/hyperledger-labs/solang/issues/908