### PR TITLE
contracts-ci-linux: fix substract-contracts-node binary download URL

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -49,7 +49,7 @@ RUN set -eux; \
 	cargo install cargo-dylint dylint-link && \
 	cargo install cargo-contract && \
 # download the latest `substrate-contracts-node` binary
-    curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/1685841/artifacts/download?job=bud-linux' && \
+    curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-linux' && \
 	unzip substrate-contracts-node.zip && \
 	mv artifacts/substrate-contracts-node-linux/substrate-contracts-node /usr/local/cargo/bin/substrate-contracts-node && \
 	rm -r artifacts substrate-contracts-node.zip && \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -49,8 +49,10 @@ RUN set -eux; \
 	cargo install cargo-dylint dylint-link && \
 	cargo install cargo-contract && \
 # download the latest `substrate-contracts-node` binary
-	curl -L "https://gitlab.parity.io/parity/substrate-contracts-node/-/jobs/artifacts/master/raw/artifacts/substrate-contracts-node-linux/substrate-contracts-node?job=build-linux" \
-		-o /usr/local/cargo/bin/substrate-contracts-node && \
+    curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/1685841/artifacts/download?job=bud-linux' && \
+	unzip substrate-contracts-node.zip && \
+	mv artifacts/substrate-contracts-node-linux/substrate-contracts-node /usr/local/cargo/bin/substrate-contracts-node && \
+	rm -r artifacts substrate-contracts-node.zip && \
 	chmod +x /usr/local/cargo/bin/substrate-contracts-node && \
 # We use `estuary` as a lightweight cargo registry in the CI to test if
 # publishing `cargo-contract` to it and installing it from there works.


### PR DESCRIPTION
The download URL is incorrect. In current `:latest` and `:production` images the `substrate-contracts-node` file is just the HTML error page instead of the actual binary :grin: 

I will use this in solang integration tests