### PR TITLE
[ci-linux] update nightly to 2022-07-25

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -21,9 +21,9 @@ RUN set -eux && \
 	# install `rust-src` component for ui test
 	rustup component add rust-src rustfmt clippy && \
 	# install specific Rust nightly, default is stable, use minimum components
-	rustup toolchain install nightly-2022-05-12 --profile minimal --component rustfmt clippy && \
-	# "alias" pinned nightly-22022-05-12 toolchain as nightly
-	ln -s /usr/local/rustup/toolchains/nightly-2022-05-12-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+	rustup toolchain install nightly-2022-07-25 --profile minimal --component rustfmt clippy && \
+	# "alias" pinned nightly-2022-07-25 toolchain as nightly
+	ln -s /usr/local/rustup/toolchains/nightly-2022-07-25-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 	# install wasm toolchain
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \


### PR DESCRIPTION
Needed for https://github.com/paritytech/substrate/pull/11903 and https://github.com/paritytech/ci_cd/issues/535