### PR TITLE
Alias pinned nightly to "normal" nightly

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -44,7 +44,11 @@ RUN set -eux; \
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy rust-src && \
-	rustup default nightly-2022-07-28 && \
+	# Alias pinned toolchain as nightly, otherwise it appears as though we
+	# don't have a nightly toolchain (i.e rustc +nightly --version is empty)
+	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
+ 	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+	rustup default nightly && \
 	cargo install cargo-dylint dylint-link && \
 	cargo install cargo-contract && \
 # download the latest `substrate-contracts-node` binary

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -69,7 +69,11 @@ RUN	set -eux; \
 # adds those components, wasm target and sets the profile to minimal
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy miri rust-src llvm-tools-preview && \
-	rustup default nightly-2022-07-28 && \
+	# Alias pinned toolchain as nightly, otherwise it appears as though we
+	# don't have a nightly toolchain (i.e rustc +nightly --version is empty)
+	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
+ 	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+	rustup default nightly && \
 # We require `xargo` so that `miri` runs properly
 # We require `grcov` for coverage reporting and `rust-covfix` to improve it.
 # We require `cargo-spellcheck` for automated spell-checking


### PR DESCRIPTION
As part of the ink! CI we have some stages which use the `+nightly`
calling convention. These ended up failing since we didn't have a
nightly toolchain, only a `+nightly-zzzz-yy-xx` one.

In the past we've had both toolchains installed, but this meant possible
inconsistencies when running those stages.

This takes inspiration from the base CI Dockerfile.
