### PR TITLE
Install `protoc` for `ink-waterfall`

### DIFF
--- a/dockerfiles/ink-waterfall-ci/Dockerfile
+++ b/dockerfiles/ink-waterfall-ci/Dockerfile
@@ -26,6 +26,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN	set -eux; \
 	apt-get -y update && \
 	apt-get install -y --no-install-recommends \
+# Required because of `libp2p-core failed to invoke protoc` during Substrate installation
+	protobuf-compiler \
 # `redis-cli` is needed to interact with ci/cd's redis
 	redis-tools \
 # npm is needed to install `yarn`


### PR DESCRIPTION
No idea why this only happens now. Our `base-ci-linux` image contains it by default.

Our waterfall Docker build currently fails with
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: NotFound, error: "failed to invoke protoc (hint: https://docs.rs/prost-build/#sourcing-protoc): No such file or directory (os error 2)" }', /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/libp2p-core-0.34.0/build.rs:30:6
```

https://gitlab.parity.io/parity/mirrors/scripts/-/jobs/1751668