### PR TITLE
Add cargo-hack to ci-linux

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux && \
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
 	# install cargo tools
-	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-nextest && \
+	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-nextest cargo-hack && \
 	cargo install --version 0.4.2 diener && \
 	# wasm-bindgen-cli version should match the one pinned in substrate
 	# https://github.com/paritytech/substrate/blob/master/bin/node/browser-testing/Cargo.toml#L15

--- a/dockerfiles/ci-linux/README.md
+++ b/dockerfiles/ci-linux/README.md
@@ -31,6 +31,8 @@ Used to build and test Substrate-based projects.
 **Rust tools & toolchains:**
 
 - `cargo-web`
+- `cargo-hack`
+- `cargo-nextest`
 - `sccache`
 - `wasm-pack`
 - `wasm-bindgen`


### PR DESCRIPTION
As discussed in https://github.com/paritytech/jsonrpsee/pull/860 cargo-hack should be added to `ci-linux`

cc @lexnv 