### PR TITLE
Use stable toolchain as default for ink! related CI images

### DIFF
--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -23,7 +23,6 @@ WORKDIR /builds
 ENV SHELL /bin/bash
 ENV DEBIAN_FRONTEND=noninteractive
 
-# install tools and dependencies
 RUN set -eux; \
 	apt-get -y update && \
 	apt-get install -y --no-install-recommends \
@@ -69,28 +68,29 @@ RUN set -eux; \
     # Install the latest released version of `cargo-contract`
 	cargo install cargo-contract && \
 
-# download the latest `substrate-contracts-node` binary
+    # Download the latest `substrate-contracts-node` binary
     curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-linux' && \
 	unzip substrate-contracts-node.zip && \
 	mv artifacts/substrate-contracts-node-linux/substrate-contracts-node /usr/local/cargo/bin/substrate-contracts-node && \
 	rm -r artifacts substrate-contracts-node.zip && \
 	chmod +x /usr/local/cargo/bin/substrate-contracts-node && \
 
-# We use `estuary` as a lightweight cargo registry in the CI to test if
-# publishing `cargo-contract` to it and installing it from there works.
+    # We use `estuary` as a lightweight cargo registry in the CI to test if
+    # publishing `cargo-contract` to it and installing it from there works.
 	cargo install --git https://github.com/onelson/estuary.git --force && \
-# versions
+
+    # Versions
 	yarn --version && \
 	rustup show && \
 	cargo --version && \
 	echo $( substrate-contracts-node --version | awk 'NF' ) && \
 	estuary --version && \
 
-# cargo clean up
-# removes compilation artifacts cargo install creates (>250M)
+    # cargo clean up
+    # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
 
-# apt clean up
+    # apt clean up
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -29,8 +29,9 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 		zlib1g-dev npm wabt llvm-dev && \
 	npm install --ignore-scripts -g yarn && \
-# `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
-# We fetch the latest release which contains a Linux binary.
+
+    # `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
+    # We fetch the latest release which contains a Linux binary.
 	curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases | \
 		egrep --only-matching 'https://github.com/WebAssembly/binaryen/releases/download/version_[0-9]+/binaryen-version_[0-9]+-x86_64-linux.tar.gz' | \
 		head -n1 | \
@@ -40,25 +41,41 @@ RUN set -eux; \
 	chmod +x binaryen-*/bin/wasm-opt && \
 	mv binaryen-*/bin/wasm-opt /usr/local/bin/ && \
 	rm -rf binaryen-*/ && \
-# Installs the latest common nightly for the listed components,
-# adds those components, wasm target and sets the profile to minimal
- 	target add wasm32-unknown-unknown --toolchain stable && \
+
+    # The stable toolchain is used to build ink! contracts through the use of the
+    # `RUSTC_BOOSTRAP=1` environment variable. We also need to install the
+    # `wasm32-unknown-unknown` target since that's the platform that ink! smart contracts
+    # run on.
+ 	rustup target add wasm32-unknown-unknown --toolchain stable && \
  	rustup component add rust-src --toolchain stable && \
+	rustup default stable && \
+
+    # We also use the nightly toolchain for linting. We perform checks using RustFmt, and
+    # Cargo Clippy.
+    #
+    # Note that we pin the nightly toolchain since it often creates breaking changes during
+    # the RustFmt and Clippy stages of the CI.
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy rust-src && \
+
 	# Alias pinned toolchain as nightly, otherwise it appears as though we
 	# don't have a nightly toolchain (i.e rustc +nightly --version is empty)
 	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
  	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
-	rustup default stable && \
+
+    # `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
 	cargo install cargo-dylint dylint-link && \
+
+    # Install the latest released version of `cargo-contract`
 	cargo install cargo-contract && \
+
 # download the latest `substrate-contracts-node` binary
     curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-linux' && \
 	unzip substrate-contracts-node.zip && \
 	mv artifacts/substrate-contracts-node-linux/substrate-contracts-node /usr/local/cargo/bin/substrate-contracts-node && \
 	rm -r artifacts substrate-contracts-node.zip && \
 	chmod +x /usr/local/cargo/bin/substrate-contracts-node && \
+
 # We use `estuary` as a lightweight cargo registry in the CI to test if
 # publishing `cargo-contract` to it and installing it from there works.
 	cargo install --git https://github.com/onelson/estuary.git --force && \
@@ -68,9 +85,11 @@ RUN set -eux; \
 	cargo --version && \
 	echo $( substrate-contracts-node --version | awk 'NF' ) && \
 	estuary --version && \
+
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
+
 # apt clean up
 	apt-get autoremove -y && \
 	apt-get clean && \

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -29,8 +29,8 @@ RUN set -eux; \
 		zlib1g-dev npm wabt llvm-dev && \
 	npm install --ignore-scripts -g yarn && \
 
-    # `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
-    # We fetch the latest release which contains a Linux binary.
+	# `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
+	# We fetch the latest release which contains a Linux binary.
 	curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases | \
 		egrep --only-matching 'https://github.com/WebAssembly/binaryen/releases/download/version_[0-9]+/binaryen-version_[0-9]+-x86_64-linux.tar.gz' | \
 		head -n1 | \
@@ -41,56 +41,56 @@ RUN set -eux; \
 	mv binaryen-*/bin/wasm-opt /usr/local/bin/ && \
 	rm -rf binaryen-*/ && \
 
-    # The stable toolchain is used to build ink! contracts through the use of the
-    # `RUSTC_BOOSTRAP=1` environment variable. We also need to install the
-    # `wasm32-unknown-unknown` target since that's the platform that ink! smart contracts
-    # run on.
- 	rustup target add wasm32-unknown-unknown --toolchain stable && \
- 	rustup component add rust-src --toolchain stable && \
+	# The stable toolchain is used to build ink! contracts through the use of the
+	# `RUSTC_BOOSTRAP=1` environment variable. We also need to install the
+	# `wasm32-unknown-unknown` target since that's the platform that ink! smart contracts
+	# run on.
+	rustup target add wasm32-unknown-unknown --toolchain stable && \
+	rustup component add rust-src --toolchain stable && \
 	rustup default stable && \
 
-    # We also use the nightly toolchain for linting. We perform checks using RustFmt, and
-    # Cargo Clippy.
-    #
-    # Note that we pin the nightly toolchain since it often creates breaking changes during
-    # the RustFmt and Clippy stages of the CI.
+	# We also use the nightly toolchain for linting. We perform checks using RustFmt, and
+	# Cargo Clippy.
+	#
+	# Note that we pin the nightly toolchain since it often creates breaking changes during
+	# the RustFmt and Clippy stages of the CI.
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy rust-src && \
 
 	# Alias pinned toolchain as nightly, otherwise it appears as though we
 	# don't have a nightly toolchain (i.e rustc +nightly --version is empty)
 	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
- 	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+		/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 
-    # `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
+	# `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
 	cargo install cargo-dylint dylint-link && \
 
-    # Install the latest released version of `cargo-contract`
+	# Install the latest released version of `cargo-contract`
 	cargo install cargo-contract && \
 
-    # Download the latest `substrate-contracts-node` binary
-    curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-linux' && \
+	# Download the latest `substrate-contracts-node` binary
+	curl -L -o substrate-contracts-node.zip 'https://gitlab.parity.io/parity/mirrors/substrate-contracts-node/-/jobs/artifacts/main/download?job=build-linux' && \
 	unzip substrate-contracts-node.zip && \
 	mv artifacts/substrate-contracts-node-linux/substrate-contracts-node /usr/local/cargo/bin/substrate-contracts-node && \
 	rm -r artifacts substrate-contracts-node.zip && \
 	chmod +x /usr/local/cargo/bin/substrate-contracts-node && \
 
-    # We use `estuary` as a lightweight cargo registry in the CI to test if
-    # publishing `cargo-contract` to it and installing it from there works.
+	# We use `estuary` as a lightweight cargo registry in the CI to test if
+	# publishing `cargo-contract` to it and installing it from there works.
 	cargo install --git https://github.com/onelson/estuary.git --force && \
 
-    # Versions
+	# Versions
 	yarn --version && \
 	rustup show && \
 	cargo --version && \
 	echo $( substrate-contracts-node --version | awk 'NF' ) && \
 	estuary --version && \
 
-    # cargo clean up
-    # removes compilation artifacts cargo install creates (>250M)
+	# cargo clean up
+	# removes compilation artifacts cargo install creates (>250M)
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
 
-    # apt clean up
+	# apt clean up
 	apt-get autoremove -y && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -42,13 +42,14 @@ RUN set -eux; \
 	rm -rf binaryen-*/ && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
+    rustup component add rust-src --toolchain stable && \
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy rust-src && \
 	# Alias pinned toolchain as nightly, otherwise it appears as though we
 	# don't have a nightly toolchain (i.e rustc +nightly --version is empty)
 	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
  	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
-	rustup default nightly && \
+	rustup default stable && \
 	cargo install cargo-dylint dylint-link && \
 	cargo install cargo-contract && \
 # download the latest `substrate-contracts-node` binary

--- a/dockerfiles/contracts-ci-linux/Dockerfile
+++ b/dockerfiles/contracts-ci-linux/Dockerfile
@@ -42,7 +42,8 @@ RUN set -eux; \
 	rm -rf binaryen-*/ && \
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
-    rustup component add rust-src --toolchain stable && \
+ 	target add wasm32-unknown-unknown --toolchain stable && \
+ 	rustup component add rust-src --toolchain stable && \
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy rust-src && \
 	# Alias pinned toolchain as nightly, otherwise it appears as though we

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -27,11 +27,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
 	apt-get -y update && \
 
-    # Needed for running commands in parallel, without overlapping output.
-    # gnupg is only needed to verify the signature of the codecov uploader.
+	# Needed for running commands in parallel, without overlapping output.
+	# gnupg is only needed to verify the signature of the codecov uploader.
 	apt-get install -y --no-install-recommends parallel gnupg && \
 
-    # codecov uploader
+	# codecov uploader
 	curl --remote-name --silent https://uploader.codecov.io/latest/linux/codecov && \
 	curl --remote-name --silent https://uploader.codecov.io/latest/linux/codecov.SHA256SUM && \
 	curl --remote-name --silent https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig && \
@@ -42,8 +42,8 @@ RUN set -eux; \
 	mv codecov /usr/local/bin/codecov && \
 	rm -f codecov.SHA256SUM codecov.SHA256SUM.sig && \
 
-    # `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
-    # We fetch the latest release which contains a Linux binary.
+	# `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
+	# We fetch the latest release which contains a Linux binary.
 	curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases | \
 		egrep --only-matching 'https://github.com/WebAssembly/binaryen/releases/download/version_[0-9]+/binaryen-version_[0-9]+-x86_64-linux.tar.gz' | \
 		head -n1 | \
@@ -54,50 +54,50 @@ RUN set -eux; \
 	mv binaryen-*/bin/wasm-opt /usr/local/bin/ && \
 	rm -rf binaryen-*/ && \
 
-    # The stable toolchain is used to build ink! itself through the use of the
-    # `RUSTC_BOOSTRAP=1` environment variable. We also need to install the
-    # `wasm32-unknown-unknown` target since that's the platform that ink! smart contracts
-    # run on.
- 	rustup target add wasm32-unknown-unknown --toolchain stable && \
- 	rustup component add rust-src --toolchain stable && \
+	# The stable toolchain is used to build ink! itself through the use of the
+	# `RUSTC_BOOSTRAP=1` environment variable. We also need to install the
+	# `wasm32-unknown-unknown` target since that's the platform that ink! smart contracts
+	# run on.
+	rustup target add wasm32-unknown-unknown --toolchain stable && \
+	rustup component add rust-src --toolchain stable && \
 	rustup default stable && \
 
-    # We also use the nightly toolchain to lint ink!. We perform checks using RustFmt,
-    # Cargo Clippy, and Miri.
-    #
-    # Note that we pin the nightly toolchain since it often creates breaking changes during
-    # the RustFmt and Clippy stages of the CI.
+	# We also use the nightly toolchain to lint ink!. We perform checks using RustFmt,
+	# Cargo Clippy, and Miri.
+	#
+	# Note that we pin the nightly toolchain since it often creates breaking changes during
+	# the RustFmt and Clippy stages of the CI.
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy miri rust-src rustc-dev llvm-tools-preview && \
 
-    # Alias pinned toolchain as nightly, otherwise it appears as though we
-    # don't have a nightly toolchain (i.e rustc +nightly --version is empty)
+	# Alias pinned toolchain as nightly, otherwise it appears as though we
+	# don't have a nightly toolchain (i.e rustc +nightly --version is empty)
 	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
- 	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+		/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 
-    # `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
+	# `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
 	cargo install cargo-dylint dylint-link && \
 
-    # Install the latest released version of `cargo-contract`
+	# Install the latest released version of `cargo-contract`
 	cargo install cargo-contract && \
 
-    # We require `grcov` for coverage reporting and `rust-covfix` to improve it.
-    # We require `xargo` so that `miri` runs properly
+	# We require `grcov` for coverage reporting and `rust-covfix` to improve it.
+	# We require `xargo` so that `miri` runs properly
 	cargo install grcov rust-covfix xargo && \
 
-    # Automated spell-checking
- 	cargo install cargo-spellcheck && \
+	# Automated spell-checking
+	cargo install cargo-spellcheck && \
 
-    # Versions
+	# Versions
 	rustup show && \
 	cargo --version && \
 	cargo-contract --version && \
 	wasm-opt --version && \
 
-    # Clean up and remove compilation artifacts that a cargo install creates (>250M).
+	# Clean up and remove compilation artifacts that a cargo install creates (>250M).
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
 
-    # apt clean up
+	# apt clean up
 	apt-get remove -y gnupg && \
 	apt-get autoremove -y && \
 	apt-get clean && \

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -24,11 +24,11 @@ ENV SHELL /bin/bash
 ENV CXX=/usr/bin/clang++-10
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN	set -eux; \
+RUN set -eux; \
+	apt-get -y update && \
 
     # Needed for running commands in parallel, without overlapping output.
     # gnupg is only needed to verify the signature of the codecov uploader.
-	apt-get -y update && \
 	apt-get install -y --no-install-recommends parallel gnupg && \
 
     # codecov uploader
@@ -75,6 +75,12 @@ RUN	set -eux; \
 	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
  	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
 
+    # `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
+	cargo install cargo-dylint dylint-link && \
+
+    # Install the latest released version of `cargo-contract`
+	cargo install cargo-contract && \
+
     # We require `grcov` for coverage reporting and `rust-covfix` to improve it.
     # We require `xargo` so that `miri` runs properly
 	cargo install grcov rust-covfix xargo && \
@@ -82,13 +88,7 @@ RUN	set -eux; \
     # Automated spell-checking
  	cargo install cargo-spellcheck && \
 
-    # `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
-	cargo install cargo-dylint dylint-link && \
-
-    # Install the latest released version of `cargo-contract`
-	cargo install cargo-contract && \
-
-    # versions
+    # Versions
 	rustup show && \
 	cargo --version && \
 	cargo-contract --version && \

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -58,7 +58,7 @@ RUN	set -eux; \
     # `RUSTC_BOOSTRAP=1` environment variable. We also need to install the
     # `wasm32-unknown-unknown` target since that's the platform that ink! smart contracts
     # run on.
- 	target add wasm32-unknown-unknown --toolchain stable && \
+ 	rustup target add wasm32-unknown-unknown --toolchain stable && \
  	rustup component add rust-src --toolchain stable && \
 	rustup default stable && \
 

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -67,13 +67,14 @@ RUN	set -eux; \
 # and targets can be used for this docker image.
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
+    rustup component add rust-src --toolchain stable && \
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy miri rust-src llvm-tools-preview && \
 	# Alias pinned toolchain as nightly, otherwise it appears as though we
 	# don't have a nightly toolchain (i.e rustc +nightly --version is empty)
 	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
  	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
-	rustup default nightly && \
+	rustup default stable && \
 # We require `xargo` so that `miri` runs properly
 # We require `grcov` for coverage reporting and `rust-covfix` to improve it.
 # We require `cargo-spellcheck` for automated spell-checking

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -67,7 +67,8 @@ RUN	set -eux; \
 # and targets can be used for this docker image.
 # Installs the latest common nightly for the listed components,
 # adds those components, wasm target and sets the profile to minimal
-    rustup component add rust-src --toolchain stable && \
+ 	target add wasm32-unknown-unknown --toolchain stable && \
+ 	rustup component add rust-src --toolchain stable && \
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy miri rust-src rustc-dev llvm-tools-preview && \
 # Alias pinned toolchain as nightly, otherwise it appears as though we

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -25,11 +25,13 @@ ENV CXX=/usr/bin/clang++-10
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN	set -eux; \
-# Needed for running commands in parallel, without overlapping output.
-# gnupg is only needed to verify the signature of the codecov uploader.
+
+    # Needed for running commands in parallel, without overlapping output.
+    # gnupg is only needed to verify the signature of the codecov uploader.
 	apt-get -y update && \
 	apt-get install -y --no-install-recommends parallel gnupg && \
-# codecov uploader
+
+    # codecov uploader
 	curl --remote-name --silent https://uploader.codecov.io/latest/linux/codecov && \
 	curl --remote-name --silent https://uploader.codecov.io/latest/linux/codecov.SHA256SUM && \
 	curl --remote-name --silent https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig && \
@@ -39,8 +41,9 @@ RUN	set -eux; \
 	chmod +x codecov && \
 	mv codecov /usr/local/bin/codecov && \
 	rm -f codecov.SHA256SUM codecov.SHA256SUM.sig && \
-# `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
-# We fetch the latest release which contains a Linux binary.
+
+    # `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
+    # We fetch the latest release which contains a Linux binary.
 	curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases | \
 		egrep --only-matching 'https://github.com/WebAssembly/binaryen/releases/download/version_[0-9]+/binaryen-version_[0-9]+-x86_64-linux.tar.gz' | \
 		head -n1 | \
@@ -50,49 +53,51 @@ RUN	set -eux; \
 	chmod +x binaryen-*/bin/wasm-opt && \
 	mv binaryen-*/bin/wasm-opt /usr/local/bin/ && \
 	rm -rf binaryen-*/ && \
-# `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
-	cargo install cargo-dylint dylint-link && \
-# The supported Rust nightly version must support the following components
-# to allow for a functioning CI pipeline:
-#
-#  - cargo: General build tool.
-#  - rustfmt: Rust formatting tool.
-#  - clippy: Rust linter.
-#  - miri: Rust interpreter with additional safety checks.
-#
-# We also need to install the wasm32-unknown-unknown target to test
-# ink! smart contracts compilation for this target architecture.
-#
-# Only Rust nightly builds supporting all of the above mentioned components
-# and targets can be used for this docker image.
-# Installs the latest common nightly for the listed components,
-# adds those components, wasm target and sets the profile to minimal
+
+    # The stable toolchain is used to build ink! itself through the use of the
+    # `RUSTC_BOOSTRAP=1` environment variable. We also need to install the
+    # `wasm32-unknown-unknown` target since that's the platform that ink! smart contracts
+    # run on.
  	target add wasm32-unknown-unknown --toolchain stable && \
  	rustup component add rust-src --toolchain stable && \
+	rustup default stable && \
+
+    # We also use the nightly toolchain to lint ink!. We perform checks using RustFmt,
+    # Cargo Clippy, and Miri.
+    #
+    # Note that we pin the nightly toolchain since it often creates breaking changes during
+    # the RustFmt and Clippy stages of the CI.
 	rustup toolchain install nightly-2022-07-28 --target wasm32-unknown-unknown \
 		--profile minimal --component rustfmt clippy miri rust-src rustc-dev llvm-tools-preview && \
-# Alias pinned toolchain as nightly, otherwise it appears as though we
-# don't have a nightly toolchain (i.e rustc +nightly --version is empty)
+
+    # Alias pinned toolchain as nightly, otherwise it appears as though we
+    # don't have a nightly toolchain (i.e rustc +nightly --version is empty)
 	ln -s /usr/local/rustup/toolchains/nightly-2022-07-28-x86_64-unknown-linux-gnu \
  	   	/usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
-	rustup default stable && \
-# We require `xargo` so that `miri` runs properly
-# We require `grcov` for coverage reporting and `rust-covfix` to improve it.
-# We require `cargo-spellcheck` for automated spell-checking
+
+    # We require `grcov` for coverage reporting and `rust-covfix` to improve it.
+    # We require `xargo` so that `miri` runs properly
 	cargo install grcov rust-covfix xargo && \
+
+    # Automated spell-checking
+ 	cargo install cargo-spellcheck && \
+
+    # `cargo-dylint` and `dylint-link` are dependencies needed to run `cargo-contract`.
+	cargo install cargo-dylint dylint-link && \
+
+    # Install the latest released version of `cargo-contract`
 	cargo install cargo-contract && \
 
-# Stuff that compiles on stable.
-  cargo +stable install cargo-spellcheck && \
-
-# versions
+    # versions
 	rustup show && \
 	cargo --version && \
 	cargo-contract --version && \
 	wasm-opt --version && \
-# Clean up and remove compilation artifacts that a cargo install creates (>250M).
+
+    # Clean up and remove compilation artifacts that a cargo install creates (>250M).
 	rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
-# apt clean up
+
+    # apt clean up
 	apt-get remove -y gnupg && \
 	apt-get autoremove -y && \
 	apt-get clean && \


### PR DESCRIPTION
After https://github.com/paritytech/cargo-contract/pull/698 we're able to build contracts
using the stable toolchain instead of nightly.

This updates our CI images to use stable as the default toolchain.
