### PR TITLE
Add `protoc` to the common base CI image

### DIFF
--- a/dockerfiles/base-ci/Dockerfile
+++ b/dockerfiles/base-ci/Dockerfile
@@ -35,7 +35,7 @@ ENV	DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
 	apt-get -y update && \
 	apt-get install -y --no-install-recommends \
-		libssl-dev clang lld libclang-dev make cmake \
+		libssl-dev clang lld libclang-dev make cmake protobuf-compiler \
 		git pkg-config curl time rhash ca-certificates \
 		jq ruby ruby-bundler git-restore-mtime python3-pip xz-utils unzip && \
 # add non-root user


### PR DESCRIPTION
Relates to https://github.com/paritytech/ci_cd/issues/627.