### PR TITLE
replace VM with Thanos

### DIFF
--- a/dockerfiles/benchmarks/check_single_bench_result.py
+++ b/dockerfiles/benchmarks/check_single_bench_result.py
@@ -93,7 +93,9 @@ def get_arguments():
     return args
 
 
-def is_metric_exceed_threshold(value1: float, value2: float, threshold: int) -> bool:
+def is_metric_exceed_threshold(
+    value1: float, value2: float, threshold: int
+) -> bool:
     return abs(100 - value1 * 100 / value2) > threshold
 
 
@@ -102,7 +104,10 @@ def is_metric_exceed_constant(value: float, constant: int) -> bool:
 
 
 def get_benchmark_last_result(
-    metric_name: str, project: str, benchmark: str, prometheus_client: PrometheusConnect
+    metric_name: str,
+    project: str,
+    benchmark: str,
+    prometheus_client: PrometheusConnect,
 ) -> float:
     """
     Get latest benchmark result from Victoria Metrics
@@ -160,6 +165,7 @@ def main():
         last_result = get_benchmark_last_result(
             args.metric, args.project, args.name, prometheus_client
         )
+        print("Last benchmark result is", last_result)
         is_metric_exceed = is_metric_exceed_threshold(
             float(args.value), last_result, int(args.threshold)
         )

--- a/dockerfiles/benchmarks/push_bench_result.py
+++ b/dockerfiles/benchmarks/push_bench_result.py
@@ -22,38 +22,52 @@ import sys
 import argparse
 import requests
 
+
 def get_arguments():
-    parser = argparse.ArgumentParser(description='Push data to Victoria Metrics.')
-    parser.add_argument('--type','-t',
-                        default='common',
-                        choices=['common', 'specific', 'test'],
-                        type=str,
-                        help='Type of benchmark: common|specific|test')
-    parser.add_argument('--project','-p',
-                        type=str,
-                        required=True,
-                        help='Benchmark project (usually name of the repo)')
-    parser.add_argument('--name','-n',
-                        type=str,
-                        required=True,
-                        help='Benchmark name')
-    parser.add_argument('--result','-r',
-                        type=str,
-                        required=True,
-                        help='Result of benchmark')
-    parser.add_argument('--labels','-l',
-                        type=str,
-                        help='Dictionary with additional labels')
-    parser.add_argument('--unit','-u',
-                        type=str,
-                        default='ns',
-                        help='Metric unit (ns,s,bytes,info...)')
-    parser.add_argument('--prometheus-server','-s',
-                        type=str,
-                        required=True,
-                        help='Prometheus server address http://prom.com')
+    parser = argparse.ArgumentParser(
+        description="Push data to Victoria Metrics."
+    )
+    parser.add_argument(
+        "--type",
+        "-t",
+        default="common",
+        choices=["common", "specific", "test"],
+        type=str,
+        help="Type of benchmark: common|specific|test",
+    )
+    parser.add_argument(
+        "--project",
+        "-p",
+        type=str,
+        required=True,
+        help="Benchmark project (usually name of the repo)",
+    )
+    parser.add_argument(
+        "--name", "-n", type=str, required=True, help="Benchmark name"
+    )
+    parser.add_argument(
+        "--result", "-r", type=str, required=True, help="Result of benchmark"
+    )
+    parser.add_argument(
+        "--labels", "-l", type=str, help="Dictionary with additional labels"
+    )
+    parser.add_argument(
+        "--unit",
+        "-u",
+        type=str,
+        default="ns",
+        help="Metric unit (ns,s,bytes,info...)",
+    )
+    parser.add_argument(
+        "--prometheus-server",
+        "-s",
+        type=str,
+        required=True,
+        help="Prometheus server address http://prom.com",
+    )
     args = parser.parse_args()
     return args
+
 
 def create_metric(args):
     """
@@ -61,30 +75,44 @@ def create_metric(args):
     Common metric doesn't have labels, test metric can have labels
     """
     if args.labels:
-        if args.type == 'common':
+        if args.type == "common":
             print("Common metric shouldn't have additional labels")
             sys.exit(1)
-        metric = f"parity_benchmark_{args.type}_result_{args.unit}{{project=\"{args.project}\",benchmark=\"{args.name}\",{args.labels}}} {args.result}"
+        metric_name = f'parity_benchmark_{args.type}_result_{args.unit}{{project="{args.project}",benchmark="{args.name}",{args.labels}}}'
     else:
-        metric = f"parity_benchmark_{args.type}_result_{args.unit}{{project=\"{args.project}\",benchmark=\"{args.name}\"}} {args.result}"
-    return metric
+        metric_name = f'parity_benchmark_{args.type}_result_{args.unit}{{project="{args.project}",benchmark="{args.name}"}}'
+    return metric_name, args.result
 
-def send_metric(server, metric):
+
+def send_metric(server, metric_name, metric_value):
     """
     Sends metric to Victoria Metrics server
     https://github.com/VictoriaMetrics/VictoriaMetrics#how-to-import-data-in-prometheus-exposition-format
+
+    https://github.com/prometheus/pushgateway#command-line
+    echo "some_metric 3.14" | curl --data-binary @- http://pushgateway.example.org:9091/metrics/job/some_job
     """
-    url = f"{server}/api/v1/import/prometheus"
-    return requests.post(url,data=metric)
+    url = f"{server}/metrics/job/${metric_name}"
+    # \n is required to signal end of input stream
+    data = f"{metric_name} {metric_value}\n"
+    print("metric_name", metric_name)
+    print("metric_value", metric_value)
+    return requests.post(url, data=data)
+
 
 def main():
     args = get_arguments()
-    metric = create_metric(args)
-    send_metric_result = send_metric(args.prometheus_server, metric)
-    if send_metric_result.text == '' and send_metric_result.status_code < 400:
-        print(f"Metric '{metric}' was successfully sent")
+    metric_name, metric_value = create_metric(args)
+    send_metric_result = send_metric(
+        args.prometheus_server, metric_name, metric_value
+    )
+    if send_metric_result.text == "" and send_metric_result.status_code < 400:
+        print(f"Metric '{metric_name} {metric_value}' was successfully sent")
     else:
-        print(f"Error occured: \nError code: {send_metric_result.status_code} \nError message: {send_metric_result.text}")
+        print(
+            f"Error occured: \nError code: {send_metric_result.status_code} \nError message: {send_metric_result.text}"
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
 Address https://github.com/paritytech/ci_cd/issues/563 
 Please see the issue for more details.
 Below are some examples extracted from the issue.
 
  <details>
  <summary> example how to push metric to pushgateway </summary>

  ```
  ./push_bench_result.py --type common \
                       --project substrate-api-sidecar \
                       --name sidecar \
                       --result 34444 \
                       --unit ms \
                       --prometheus-server http://pushgateway.parity-build.parity.io
  metric_name parity_benchmark_common_result_ms{project="substrate-api-sidecar",benchmark="sidecar"}
  metric_value 34444
  Metric 'parity_benchmark_common_result_ms{project="substrate-api-sidecar",benchmark="sidecar"} 34444' was successfully   sent
  ```
  </details>

  <details>
  <summary> example: get metrics from Thanos</summary>
  
  ```bash
  ./check_single_bench_result.py --metric parity_benchmark_common_result_ms  \
                                                     --project substrate-api-sidecar \ 
                                                     --name sidecar \
                                                     --prometheus-server 'https://thanos.parity-mgmt.parity.io/'  \
                                                     --github-repo 'paritytech/substrate-api-sidecar'  \
                                                     --threshold 20 \
                                                    --value 35000
  /home/radu/.virtualenvs/benchmark/lib/python3.10/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning:       Unverified HTTPS request is being made to host 'thanos.parity-mgmt.parity.io'. Adding certificate verification is strongly advised.  See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
      warnings.warn(
    /home/radu/.virtualenvs/benchmark/lib/python3.10/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning:  Unverified HTTPS request is being made to host 'thanos.parity-mgmt.parity.io'. Adding certificate verification is strongly advised See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
      warnings.warn(
    Last benchmark result is 33333.0
    No regressions
  ```