### PR TITLE
Add mdbook utils to ci-linux

### DIFF
--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -38,7 +38,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux; \
 	apt-get -y update; \
 	apt-get install -y --no-install-recommends \
-		libssl-dev make cmake \
+		libssl-dev make cmake graphviz \
 		git pkg-config curl time rhash ca-certificates \
 		python3 python3-pip lsof ruby ruby-bundler git-restore-mtime xz-utils unzip gnupg protobuf-compiler && \
 # add clang 13 repo

--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -28,7 +28,8 @@ RUN set -eux && \
 	rustup target add wasm32-unknown-unknown && \
 	rustup target add wasm32-unknown-unknown --toolchain nightly && \
 	# install cargo tools
-	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-nextest cargo-hack && \
+	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-nextest cargo-hack \
+	            mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed && \
 	cargo install --version 0.4.2 diener && \
 	# wasm-bindgen-cli version should match the one pinned in substrate
 	# https://github.com/paritytech/substrate/blob/master/bin/node/browser-testing/Cargo.toml#L15

--- a/dockerfiles/ci-linux/README.md
+++ b/dockerfiles/ci-linux/README.md
@@ -39,6 +39,7 @@ Used to build and test Substrate-based projects.
 - `cargo-deny`
 - `cargo-spellcheck`: Required for the CI to do automated spell-checking.
 - `wasm32-unknown-unknown` toolchain
+- `mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed`
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/ci-linux) for the registry.
 


### PR DESCRIPTION
I suggest to install this tools for the `build-implementers-guide` job in polkadot pipeline

cc https://github.com/paritytech/polkadot/pull/6216