### PR TITLE
Add cargo nextest installation

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -97,6 +97,9 @@ RUN set -eux; \
 	# Automated spell-checking
 	cargo install cargo-spellcheck && \
 
+	# More faster test runner for Rust projects than cargo-test 
+	cargo install cargo-nextest  && \
+
 	# Versions
 	rustup show && \
 	cargo --version && \

--- a/dockerfiles/ink-ci-linux/README.md
+++ b/dockerfiles/ink-ci-linux/README.md
@@ -44,7 +44,8 @@ We always use the [latest possible](https://rust-lang.github.io/rustup-component
 - `xargo`: Required so that `miri` runs properly.
 - `cargo-spellcheck`: Required for the CI to do automated spell-checking.
 - `wasm32-unknown-unknown`: The toolchain to compile Rust codebases for Wasm.
-- `llvm-tools-preview`: or MIR source-based Rust coverage instrumentation.
+- `llvm-tools-preview`: our MIR source-based Rust coverage instrumentation.
+- `cargo-nextest`: Test runner for Rust project, to replace cargo test.
 
 [Click here](https://hub.docker.com/repository/docker/paritytech/ink-ci-linux) for the registry.
 


### PR DESCRIPTION
Add cargo nextest Install to improve test performance in DockerFile, 
First Part of these CI changes for ink!, https://github.com/paritytech/ink/issues/1474

