### PR TITLE
Bump kubectl to 1.24

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -344,7 +344,7 @@ kubetools-kubectl:
   <<:                              *docker_build
   variables:
     <<:                            *default-vars
-    KUBE_VERSION:                  "1.22.15"
+    KUBE_VERSION:                  "1.24.7"
   script:
     - buildah bud
       --format=docker


### PR DESCRIPTION
Signed-off-by: bakhtin <a@bakhtin.net>

Bump kubectl to 1.24 as it has some new features. I personally require this to work:
`kubectl wait --for=jsonpath='{.status.replicas}'=0 --timeout=-1s sts/$STS_NAME`
which is not available in 1.22. 

1.24 kubectl should be compatible with both 1.22 and 1.23 versions of the server though we'll preserve 1.22 remote tag.