### PR TITLE
Use `clang-15` for `paritytech/base-ci-linux`

### DIFF
--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -31,8 +31,8 @@ COPY utility/base-ci-linux-config /root/.cargo/config
 ENV RUSTUP_HOME=/usr/local/rustup \
 	CARGO_HOME=/usr/local/cargo \
 	PATH=/usr/local/cargo/bin:$PATH \
-		CC=clang-14 \
-		CXX=clang-14
+		CC=clang-15 \
+		CXX=clang-15
 
 # install tools and dependencies
 RUN set -eux; \
@@ -41,13 +41,13 @@ RUN set -eux; \
 		libssl-dev make cmake graphviz \
 		git pkg-config curl time rhash ca-certificates \
 		python3 python3-pip lsof ruby ruby-bundler git-restore-mtime xz-utils unzip gnupg protobuf-compiler && \
-# add clang 14 repo
+# add clang 15 repo
 	curl -s https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
-	echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-14 main" >> /etc/apt/sources.list.d/llvm-toochain-buster-14.list; \
-	echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-14 main" >> /etc/apt/sources.list.d/llvm-toochain-buster-14.list; \
+	echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-15 main" >> /etc/apt/sources.list.d/llvm-toochain-buster-15.list; \
+	echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-15 main" >> /etc/apt/sources.list.d/llvm-toochain-buster-15.list; \
 	apt-get -y update; \
 	apt-get install -y --no-install-recommends \
-		clang-14 lldb-14 lld-14 libclang-14-dev && \
+		clang-15 lldb-15 lld-15 libclang-15-dev && \
 # add non-root user
   groupadd -g 1000 nonroot && \
   useradd -u 1000 -g 1000 -s /bin/bash -m nonroot && \
@@ -61,7 +61,7 @@ RUN set -eux; \
   curl -L "https://dl.min.io/client/mc/release/linux-amd64/mc" -o /usr/local/bin/mc && \
   chmod 755 /usr/local/bin/mc && \
 # set a link to clang
-	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-14 100; \
+	update-alternatives --install /usr/bin/cc cc /usr/bin/clang-15 100; \
 # install rustup, use minimum components
 	curl -L "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
 		-o rustup-init; \

--- a/dockerfiles/base-ci-linux/README.md
+++ b/dockerfiles/base-ci-linux/README.md
@@ -11,9 +11,9 @@ Used to build and test Substrate-based projects.
 **Dependencies and Tools:**
 
 - `libssl-dev`
-- `clang-14`
-- `lld-14`
-- `libclang-14-dev`
+- `clang-15`
+- `lld-15`
+- `libclang-15-dev`
 - `make`
 - `cmake`
 - `git`

--- a/dockerfiles/utility/base-ci-linux-config
+++ b/dockerfiles/utility/base-ci-linux-config
@@ -1,9 +1,9 @@
 [target.wasm32-unknown-unknown]
 runner = "node"
-linker="clang-14"
+linker="clang-15"
 
 [target.x86_64-unknown-linux-gnu]
 # Enables the aes-ni instructions for RustCrypto dependency.
 rustflags = ["-Ctarget-feature=+aes,+sse2,+ssse3"]
 # setup clang as Linker
-linker="clang-14"
+linker="clang-15"


### PR DESCRIPTION
`clang-14` is still too low for the CI workloads even there were reports that it fixes related linker problems locally. Bumping further to `clang-15`.

cc @muharem @samelamin