### PR TITLE
Update base-ci-linux base image to 'bullseye-slim' tag

### DIFF
--- a/dockerfiles/base-ci-linux/Dockerfile
+++ b/dockerfiles/base-ci-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/debian:buster-slim
+FROM docker.io/library/debian:bullseye-slim
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""


### PR DESCRIPTION
New version has updated glibc. 