### PR TITLE
Add new image: `xbuilder-aarch64-unknown-linux-gnu`

### DIFF
--- a/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/Dockerfile
+++ b/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/Dockerfile
@@ -17,15 +17,14 @@ LABEL summary="Cross Builder for aarch64-unknown-linux-gnu targets" \
 
 USER root
 
-RUN apt update && apt upgrade -y
-RUN apt install -y \
+RUN apt update && apt upgrade -y && \
+    apt install -y \
         g++-aarch64-linux-gnu libc6-dev-arm64-cross \
         pkg-config libssl-dev \
         protobuf-compiler clang make bsdmainutils && \
-        rm -rf /var/lib/apt/lists/* /tmp/* && apt clean
-
-RUN rustup target add aarch64-unknown-linux-gnu
-RUN rustup toolchain install stable-aarch64-unknown-linux-gnu
+        rm -rf /var/lib/apt/lists/* /tmp/* && apt clean && \
+    rustup target add aarch64-unknown-linux-gnu && \
+    rustup toolchain install stable-aarch64-unknown-linux-gnu
 
 WORKDIR /app
 

--- a/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/Dockerfile
+++ b/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/Dockerfile
@@ -5,11 +5,11 @@ FROM rust:latest
 # metadata
 LABEL summary="Cross Builder for aarch64-unknown-linux-gnu targets" \
 	name="${REGISTRY_PATH}/xbuilder-aarch64-unknown-linux-gnu" \
-	maintainer="devops-team@parity.io" \
 	version="1.0" \
-    io.parity.image.authors="chevdor@gmail.com, devops-team@parity.io" \
 	description="Parity xbuilder-aarch64-unknown-linux-gnu container" \
+	maintainer="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
+    io.parity.image.authors="chevdor@gmail.com, devops-team@parity.io" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/parity-keyring/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/parity-keyring/README.md" \
 	io.parity.image.revision="${VCS_REF}" \

--- a/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/Dockerfile
+++ b/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,37 @@
+ARG REGISTRY_PATH=docker.io/paritytech
+
+FROM rust:latest
+
+# metadata
+LABEL summary="Cross Builder for aarch64-unknown-linux-gnu targets" \
+	name="${REGISTRY_PATH}/xbuilder-aarch64-unknown-linux-gnu" \
+	maintainer="devops-team@parity.io" \
+	version="1.0" \
+	description="Parity xbuilder-aarch64-unknown-linux-gnu container" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/parity-keyring/Dockerfile" \
+	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/parity-keyring/README.md" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}"
+
+USER root
+
+RUN apt update && apt upgrade -y
+RUN apt install -y \
+        g++-aarch64-linux-gnu libc6-dev-arm64-cross \
+        pkg-config libssl-dev \
+        protobuf-compiler clang make bsdmainutils && \
+        rm -rf /var/lib/apt/lists/* /tmp/* && apt clean
+
+RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup toolchain install stable-aarch64-unknown-linux-gnu
+
+WORKDIR /app
+
+ENV SKIP_WASM_BUILD=1 \
+    CC_aarch64_unknown_linux_gnu="aarch64-linux-gnu-gcc" \
+    CXX_aarch64_unknown_linux_gnu="aarch64-linux-gnu-g++" \
+    BINDGEN_EXTRA_CLANG_ARGS="-I/usr/aarch64-linux-gnu/include/" \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
+
+ENTRYPOINT ["cargo", "build", "--target", "aarch64-unknown-linux-gnu"]

--- a/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/Dockerfile
+++ b/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/Dockerfile
@@ -7,6 +7,7 @@ LABEL summary="Cross Builder for aarch64-unknown-linux-gnu targets" \
 	name="${REGISTRY_PATH}/xbuilder-aarch64-unknown-linux-gnu" \
 	maintainer="devops-team@parity.io" \
 	version="1.0" \
+    io.parity.image.authors="chevdor@gmail.com, devops-team@parity.io" \
 	description="Parity xbuilder-aarch64-unknown-linux-gnu container" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/parity-keyring/Dockerfile" \

--- a/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/README.md
+++ b/dockerfiles/xbuilder-aarch64-unknown-linux-gnu/README.md
@@ -1,0 +1,23 @@
+# xbuilder-aarch64-unknown-linux-gnu
+
+A Docker image to cross build using the `aarch64-unknown-linux-gnu` target.
+This is used to make `arm64` binaries.
+
+## Usage
+
+Here is a sample use to build the `polkadot` binary:
+```
+TARGET=aarch64-unknown-linux-gnu
+docker run --rm -ti \
+	-v $PWD:/app parity-xbuilder-${TARGET} \
+	-p polkadot \
+	--profile production
+```
+
+## Build
+
+```
+TARGET=aarch64-unknown-linux-gnu
+docker build -t parity-xbuilder-${TARGET} -f xbuilder-aarch64-linux-gnu.Dockerfile .
+docker images | grep ${TARGET}
+```


### PR DESCRIPTION
A new Docker image to support cross building binaries for `aarch64-unknown-linux-gnu` (arm64).
See also https://github.com/paritytech/polkadot/pull/6108

- [ ] Merge PR
- [ ] Setup CI for automatic scheduled builds (weekly ?) in [here](https://gitlab.parity.io/parity/mirrors/scripts/-/pipeline_schedules)

I pushed an image to `chevdor/parity-xbuilder-aarch64-unknown-linux-gnu`. This image will however **not** be able to build polkadot master until https://github.com/paritytech/polkadot/pull/6108 is merged. In the meantime, the [branch of the PR](https://github.com/paritytech/polkadot/tree/wk-221004-target-aarch64-apple-darwin) can be built.

## Sample use

Production builds are done using the `production` profile but for testing, `release` is slightly faster to build.

```
# TODO: Switch to the official parity image once available
IMAGE=chevdor/parity-xbuilder-aarch64-unknown-linux-gnu

time docker run --rm --name builder  -v $PWD:/app ${IMAGE} --package polkadot --profile release
```
