### PR TITLE
Update node version in node-wrk image

### DIFF
--- a/dockerfiles/node-wrk/Dockerfile
+++ b/dockerfiles/node-wrk/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux && \
 ARG VCS_REF=master
 ARG BUILD_DATE=""
 
-FROM node:16-slim
+FROM node:18-slim
 
 LABEL summary="Image for Substrate-api-sidecar benchmarks" \
 	name="${REGISTRY_PATH}/sidecar-bench" \


### PR DESCRIPTION
Current version doesn't have `yarn`. Needed for https://github.com/paritytech/ci_cd/issues/739