### PR TITLE
Update get-substrate.sh

### DIFF
--- a/get-substrate.sh
+++ b/get-substrate.sh
@@ -11,9 +11,9 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 
 	if [ -f /etc/redhat-release ]; then
 		echo "Redhat Linux detected."
-		echo "This OS is not supported with this script at present. Sorry."
-		echo "Please refer to https://github.com/paritytech/substrate for setup information."
-		exit 1
+		$MAKE_ME_ROOT yum update -y
+		$MAKE_ME_ROOT yum groupinstall -y "Development Tools"
+		$MAKE_ME_ROOT yum install -y cmake openssl-devel git protobuf protobuf-compiler clang clang-devel 
 	elif [ -f /etc/SuSE-release ]; then
 		echo "Suse Linux detected."
 		echo "This OS is not supported with this script at present. Sorry."
@@ -32,7 +32,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	elif [ -f /etc/debian_version ]; then
 		echo "Ubuntu/Debian Linux detected."
 		$MAKE_ME_ROOT apt update
-		$MAKE_ME_ROOT apt install -y cmake pkg-config libssl-dev git gcc build-essential git clang libclang-dev
+		$MAKE_ME_ROOT apt install -y cmake pkg-config libssl-dev git gcc build-essential git protobuf protobuf-compiler clang libclang-dev 
 	else
 		echo "Unknown Linux distribution."
 		echo "This OS is not supported with this script at present. Sorry."


### PR DESCRIPTION
you can install dependencies package for Rust and Substrate framework with this script written script is useable for Redhat systems like Rocky linux, Alma linux, Centos and etc. Development Tools group use for build and complie system's projects;
 important package inside in Development Tools is:
  autoconf, automake, binutils, libtool, gcc, pkgconf, rpm-build and etc. 
openssl-devel: share object libraries for openssl
clang-devel: share object libraries for clang
protobuf: Protocol Buffers are Google's language-neutral, platform-neutral, extensible mechanism for serializing structured data
 we use for compile substrate framework becuse libp2p use protobuf libraries
protobuf-compiler: development tools for protobuf