### PR TITLE
Add new Docker image for the `releng-scripts` repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,15 +290,39 @@ xbuilder-aarch64-unknown-linux-gnu:
   variables:
     IMAGE_NAME:                    "xbuilder-aarch64-unknown-linux-gnu"
 
+# releng-scripts needs custom config because files are in a separate repo
+releng-scripts-download-pr:
+  stage:                           build
+  image:                           "paritytech/ci-linux:production"
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    when: on_success
+    expire_in: 3 hours
+    paths:
+      - ./artifacts/
+  variables:
+    GIT_FETCH: 0
+  rules:
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      changes:
+        - dockerfiles/releng-scripts/**
+  script:
+    - mkdir -p artifacts/
+    - cd artifacts/
+    - git clone https://github.com/paritytech/releng-scripts
+  tags:
+    - kubernetes-parity-build
+
 releng-scripts-pr:
   <<: *docker_build_pr
+  needs:
+    - job: releng-scripts-download-pr
+      artifacts: true
   variables:
     IMAGE_NAME:                    "releng-scripts"
   script:
-    - cd dockerfiles/$IMAGE_NAME
-    - git clone https://github.com/paritytech/releng-scripts
-    - mv Dockerfile releng-scripts/
-    - cd releng-scripts/
+    - mv dockerfiles/$IMAGE_NAME/Dockerfile artifacts/releng-scripts/
+    - cd artifacts/releng-scripts/
     - buildah bud
       --format=docker
       --build-arg VCS_REF="$CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,6 +290,23 @@ xbuilder-aarch64-unknown-linux-gnu:
   variables:
     IMAGE_NAME:                    "xbuilder-aarch64-unknown-linux-gnu"
 
+releng-scripts-pr:
+  <<: *docker_build_pr
+  variables:
+    IMAGE_NAME:                    "releng-scripts"
+  script:
+    - cd dockerfiles/$IMAGE_NAME
+    - git clone https://github.com/paritytech/releng-scripts
+    - mv Dockerfile releng-scripts/
+    - cd releng-scripts/
+    - buildah bud
+      --format=docker
+      --build-arg VCS_REF="$CI_COMMIT_SHA"
+      --build-arg BUILD_DATE="$(date +%Y%m%d)"
+      --build-arg REGISTRY_PATH="$REGISTRY_PATH"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:staging"
+      --file "Dockerfile"
+
 # Build and push to docker hub
 ansible:
   <<:                              *docker_build
@@ -662,6 +679,26 @@ substrate-session-keys-grabber:
     - *push_to_docker_hub
   variables:
     IMAGE_NAME:                    "substrate-session-keys-grabber"
+
+releng-scripts:
+  <<:                              *docker_build
+  script:
+    - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
+    - buildah version
+    - buildah bud
+        --format=docker
+        --build-arg VCS_REF="$CI_COMMIT_SHA"
+        --build-arg BUILD_DATE="$(date +%Y%m%d)"
+        --build-arg REGISTRY_PATH="$REGISTRY_PATH"
+        --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+        --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
+        --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
+    - buildah info
+    - echo "$Docker_Hub_Pass_Parity" |
+        buildah login --username "$Docker_Hub_User_Parity" --password-stdin "$REGISTRY_NAME"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+    - buildah push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:latest"
+    - buildah logout "$REGISTRY_NAME"
 
 #### stage:                        test
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -704,19 +704,46 @@ substrate-session-keys-grabber:
   variables:
     IMAGE_NAME:                    "substrate-session-keys-grabber"
 
-releng-scripts:
-  <<:                              *docker_build
+# releng-scripts needs custom ci config because files are in a separate repo
+releng-scripts-download:
+  stage:                           build
+  image:                           "paritytech/ci-linux:production"
+  artifacts:
+    name: "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    when: on_success
+    expire_in: 3 hours
+    paths:
+      - ./artifacts/
+  variables:
+    GIT_FETCH: 0
+  rules:
+    - if: $IMAGE_NAME == "releng-scripts"
   script:
+    - mkdir -p artifacts/
+    - cd artifacts/
+    - git clone https://github.com/paritytech/releng-scripts
+  tags:
+    - kubernetes-parity-build
+
+releng-scripts:
+  <<: *docker-build
+  needs:
+    - job: releng-scripts-download
+      artifacts: true
+  variables:
+    IMAGE_NAME:                    "releng-scripts"
+  script:
+    - mv dockerfiles/$IMAGE_NAME/Dockerfile artifacts/releng-scripts/
+    - cd artifacts/releng-scripts/
     - export IMAGE_DATE_TAG="$CI_COMMIT_SHORT_SHA-$(date +%Y%m%d)"
-    - buildah version
     - buildah bud
-        --format=docker
-        --build-arg VCS_REF="$CI_COMMIT_SHA"
-        --build-arg BUILD_DATE="$(date +%Y%m%d)"
-        --build-arg REGISTRY_PATH="$REGISTRY_PATH"
-        --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
-        --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
-        --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
+      --format=docker
+      --build-arg VCS_REF="$CI_COMMIT_SHA"
+      --build-arg BUILD_DATE="$(date +%Y%m%d)"
+      --build-arg REGISTRY_PATH="$REGISTRY_PATH"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:$IMAGE_DATE_TAG"
+      --tag "$REGISTRY_PATH/$IMAGE_NAME:latest"
+      --file "Dockerfile"
     - buildah info
     - echo "$Docker_Hub_Pass_Parity" |
         buildah login --username "$Docker_Hub_User_Parity" --password-stdin "$REGISTRY_NAME"
@@ -1124,3 +1151,9 @@ publish-xbuilder-aarch64-unknown-linux-gnu-docker-image-description:
   variables:
     IMAGE_NAME:           xbuilder-aarch64-unknown-linux-gnu
     SHORT_DESCRIPTION:    "xbuilder-aarch64-unknown-linux-gnu utility Docker image."
+
+publish-releng-scripts-docker-image-description:
+  extends:                .publish-docker-image-description
+  variables:
+    IMAGE_NAME:           releng-scripts
+    SHORT_DESCRIPTION:    "releng-scripts Docker image."

--- a/dockerfiles/releng-scripts/.dockerignore
+++ b/dockerfiles/releng-scripts/.dockerignore
@@ -1,0 +1,7 @@
+.env*
+!.env-sample
+tests
+.github
+.git
+.*
+CODEOWNERS

--- a/dockerfiles/releng-scripts/.dockerignore
+++ b/dockerfiles/releng-scripts/.dockerignore
@@ -5,3 +5,4 @@ tests
 .git
 .*
 CODEOWNERS
+ 

--- a/dockerfiles/releng-scripts/.dockerignore
+++ b/dockerfiles/releng-scripts/.dockerignore
@@ -5,4 +5,3 @@ tests
 .git
 .*
 CODEOWNERS
- 

--- a/dockerfiles/releng-scripts/Dockerfile
+++ b/dockerfiles/releng-scripts/Dockerfile
@@ -1,0 +1,34 @@
+ARG REGISTRY_PATH=docker.io/paritytech
+
+FROM docker.io/library/ubuntu:latest
+
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+ARG UID=1000
+ARG GID=1000
+
+# metadata
+LABEL summary="Base image for GnuPG operations" \
+	name="${REGISTRY_PATH}/gnupg" \
+	maintainer="devops-team@parity.io" \
+	version="1.0" \
+	description="GnuPG base container" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/gnupg/Dockerfile" \
+	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/gnupg/README.md" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}"
+
+RUN apt-get update && apt-get install -yq --no-install-recommends bash ca-certificates curl gnupg
+
+WORKDIR /scripts
+
+COPY . .
+
+RUN set -x \
+    && groupadd -g $GID nonroot \
+    && useradd -u $UID -g $GID -s /bin/bash -m nonroot
+
+USER nonroot:nonroot
+
+ENTRYPOINT [ "./rs" ]

--- a/dockerfiles/releng-scripts/Dockerfile
+++ b/dockerfiles/releng-scripts/Dockerfile
@@ -4,8 +4,8 @@ FROM docker.io/library/ubuntu:latest
 
 ARG VCS_REF=master
 ARG BUILD_DATE=""
-ARG UID=1000
-ARG GID=1000
+ARG UID=10000
+ARG GID=10000
 
 # metadata
 LABEL summary="Base image for GnuPG operations" \
@@ -26,8 +26,8 @@ WORKDIR /scripts
 COPY . .
 
 RUN set -x \
-    && groupadd -g $GID nonroot \
-    && useradd -u $UID -g $GID -s /bin/bash -m nonroot
+	&& groupadd -g $GID nonroot \
+	&& useradd -u $UID -g $GID -s /bin/bash -m nonroot
 
 USER nonroot:nonroot
 

--- a/dockerfiles/releng-scripts/README.md
+++ b/dockerfiles/releng-scripts/README.md
@@ -1,0 +1,18 @@
+# releng-scripts
+
+Docker image based on [official Ubuntu image](https://hub.docker.com/_/ubuntu) ubuntu:latest.
+
+This is an image for the scripts located in this repo: https://github.com/paritytech/releng-scripts
+
+## Build
+
+The provided `build.sh` script clones [the repo](https://github.com/paritytech/releng-scripts) and builds the image.
+
+## Usage
+
+```bash
+# Show the help
+docker run --rm -it paritytech/releng-scripts
+# Show the version
+docker run --rm -it paritytech/releng-scripts version
+```

--- a/dockerfiles/releng-scripts/build.sh
+++ b/dockerfiles/releng-scripts/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+REPO=https://github.com/paritytech/releng-scripts
+REGISTRY_PATH=${REGISTRY_PATH:-paritytech}
+DOCKER_IMAGE_NAME=releng-scripts
+
+REPO_TMP=$(mktemp -d)
+echo "Cloning ${REPO} into ${REPO_TMP}"
+git clone ${REPO} "${REPO_TMP}"
+
+docker build \
+    -t "${DOCKER_IMAGE_NAME}" \
+    -t "${REGISTRY_PATH}/${DOCKER_IMAGE_NAME}" \
+    "${REPO_TMP}"
+
+docker images | grep "${DOCKER_IMAGE_NAME}"
+
+# Testing
+docker run --rm -it ${DOCKER_IMAGE_NAME}
+docker run --rm -it ${DOCKER_IMAGE_NAME} version


### PR DESCRIPTION
As discussed with @alvicsam, this PR adds a new Dockerfile as well as the script required to build the image.
The `build.sh` script mainly git clones the releng-scripts repo in order to build the image.

Testing can be done as mentioned in https://github.com/paritytech/releng-scripts/pull/34

## Once merged
- [ ] @alvicsam setup weekly build with the ability for a manual trigger
- [ ] @chevdor remove the docker image related files from the releng-scripts repo
- [ ] @chevdor fix doc in the releng-scripts repo