### PR TITLE
ci-linux: revert rust nightly to 2023-03-15

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -4,7 +4,7 @@ ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/base-ci-linux:latest
 
-ARG RUST_NIGHTLY="2023-03-16"
+ARG RUST_NIGHTLY="2023-03-15"
 
 # metadata
 LABEL summary="Image for Substrate-based projects." \


### PR DESCRIPTION
2023-03-16 is broken,
cf https://github.com/rust-lang/rust/issues/109199