### PR TITLE
ci-linux: Revert nightly rust to 2022-11-16

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -4,7 +4,7 @@ ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/base-ci-linux:latest
 
-ARG RUST_NIGHTLY="2023-03-15"
+ARG RUST_NIGHTLY="2022-11-16"
 
 # metadata
 LABEL summary="Image for Substrate-based projects." \


### PR DESCRIPTION
The current nightlies introduce a ton of new clippy warnings, and their clippy is also mildly buggy, which makes it a pain to fix everything.

Given we're hopefully getting rid of the nightly toolchain very soon anyway, let's just revert it for now rather than sinking an inordinate amount of effort into the bump.