### PR TITLE
Fix bridges build

### DIFF
--- a/dockerfiles/bridges-ci/Dockerfile
+++ b/dockerfiles/bridges-ci/Dockerfile
@@ -22,6 +22,7 @@ dockerfiles/bridges-ci/README.md" \
 
 RUN rustup toolchain install nightly --target wasm32-unknown-unknown \
 		--profile minimal --component clippy rustfmt && \
+	rustup target add wasm32-unknown-unknown && \
 	cargo install cargo-deny cargo-spellcheck && \
 # cargo clean up
 # removes compilation artifacts cargo install creates (>250M)


### PR DESCRIPTION
Related to: https://github.com/paritytech/parity-bridges-common/issues/2035

The bridges builds are failing lately. For example: https://gitlab.parity.io/parity/mirrors/parity-bridges-common/-/jobs/2683372

With error message:

```
Rust WASM toolchain not installed, please install it!
```

That's because the `wasm32-unknown-unknown` is not installed for the stable rust toolchain