### PR TITLE
add docker image for the GitHubClI tools

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,6 +161,11 @@ contracts-ci-linux-pr:
   variables:
     IMAGE_NAME:                    "contracts-ci-linux"
 
+github-gh-cli-pr:
+  <<: *docker_build_pr
+  variables:
+    IMAGE_NAME:                    "github-gh-cli"
+
 ink-ci-linux-pr:
   <<: *docker_build_pr
   variables:
@@ -369,6 +374,11 @@ contracts-ci-linux:
     - *push_to_docker_hub
 
 debian10:
+  <<:                              *docker_build
+  script:
+    - *push_to_docker_hub
+
+github-gh-cli:
   <<:                              *docker_build
   script:
     - *push_to_docker_hub

--- a/dockerfiles/github-gh-cli/Dockerfile
+++ b/dockerfiles/github-gh-cli/Dockerfile
@@ -1,0 +1,26 @@
+ARG REGISTRY_PATH=docker.io/paritytech
+
+FROM docker.io/library/ubuntu:latest
+
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+
+# metadta
+LABEL summary="Base image with git and gh (GitHub CLI)" \
+	name="${REGISTRY_PATH}/github-gh-cli" \
+	maintainer="devops-team@parity.io" \
+	version="1.0" \
+	description="Image contains git and gh tools." \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/github-gh-cli/Dockerfile" \
+	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/github-gh-cli/gnupg/README.md" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}"
+
+RUN apt-get update && apt-get install -yq --no-install-recommends bash ca-certificates git gh; \
+    # verify gh binary works
+    gh --version;
+
+WORKDIR /tmp/repo
+
+CMD ["gh"]

--- a/dockerfiles/github-gh-cli/README.md
+++ b/dockerfiles/github-gh-cli/README.md
@@ -1,0 +1,18 @@
+# GitHub CLI
+
+Docker image based on [official Ubuntu image](https://hub.docker.com/_/ubuntu) ubuntu:latest.
+
+Used as base for tooling that requires git and gh.
+
+**Tools:**
+
+- `git`
+- `gh`
+
+[Click here](https://hub.docker.com/repository/docker/paritytech/github-gh-cli) for the registry.
+
+## Usage
+
+```
+docker run --rm -it -v $PWD:/tmp/repo docker.io/paritytech/github-gh-cli gh {needed_gh_command}
+```


### PR DESCRIPTION
This PR adds a Docker image which contains `git` and `gh` so that it could be used on the cleanroom for doing some github stuff like PR creation from the command line. 
As an example, it will be needed for the release  automation of the `parity-keyring`