### PR TITLE
Introduce unified CI image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,18 +359,20 @@ ci-unified:
   script:
     - RUST_STABLE_VERSION=$(grep 'RUST_STABLE_VERSION' dockerfiles/$IMAGE_NAME/Dockerfile | cut -d '"' -f 2)
     - DISTRO_CODENAME=$(grep 'DISTRO_CODENAME' dockerfiles/$IMAGE_NAME/Dockerfile | cut -d '"' -f 2)
-    - TAG_TUPLE="${RUST_STABLE_VERSION}-${DISTRO_CODENAME}"
+    - TAG_TUPLE="${DISTRO_CODENAME}-${RUST_STABLE_VERSION}"
     - $BUILDAH_COMMAND build
         --format=docker
         --build-arg VCS_REF="$CI_COMMIT_SHA"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
         --build-arg REGISTRY_PATH="$REGISTRY_PATH"
         --tag "$REGISTRY_PATH/$IMAGE_NAME:$TAG_TUPLE"
+        --tag "$REGISTRY_PATH/$IMAGE_NAME:$DISTRO_CODENAME"
         --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
   - $BUILDAH_COMMAND info
   - echo "$Docker_Hub_Pass_Parity" |
       buildah login --username "$Docker_Hub_User_Parity" --password-stdin "$REGISTRY_NAME"
   - $BUILDAH_COMMAND push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$TAG_TUPLE"
+  - $BUILDAH_COMMAND push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$DISTRO_CODENAME"
   - buildah logout "$REGISTRY_NAME"
   tags:
     - linux-docker-vm-c2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -354,6 +354,26 @@ ci-linux:
     - $BUILDAH_COMMAND push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$VERSION_TAG"
     - buildah logout "$REGISTRY_NAME"
 
+ci-unified:
+  <<:                              *docker_build
+  script:
+    - RUST_STABLE_VERSION=$(grep 'RUST_STABLE_VERSION' dockerfiles/$IMAGE_NAME/Dockerfile | cut -d '"' -f 2)
+    - DISTRO_CODENAME=$(grep 'DISTRO_CODENAME' dockerfiles/$IMAGE_NAME/Dockerfile | cut -d '"' -f 2)
+    - TAG_TUPLE="${RUST_STABLE_VERSION}-${DISTRO_CODENAME}"
+    - $BUILDAH_COMMAND build
+        --format=docker
+        --build-arg VCS_REF="$CI_COMMIT_SHA"
+        --build-arg BUILD_DATE="$(date +%Y%m%d)"
+        --build-arg REGISTRY_PATH="$REGISTRY_PATH"
+        --tag "$REGISTRY_PATH/$IMAGE_NAME:$TAG_TUPLE"
+        --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
+  - $BUILDAH_COMMAND info
+  - echo "$Docker_Hub_Pass_Parity" |
+      buildah login --username "$Docker_Hub_User_Parity" --password-stdin "$REGISTRY_NAME"
+  - $BUILDAH_COMMAND push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$TAG_TUPLE"
+  - buildah logout "$REGISTRY_NAME"
+  tags:
+    - linux-docker-vm-c2
 
 ink-ci-linux:
   <<:                              *docker_build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -357,8 +357,8 @@ ci-linux:
 ci-unified:
   <<:                              *docker_build
   script:
-    - RUST_STABLE_VERSION=$(grep 'RUST_STABLE_VERSION' dockerfiles/$IMAGE_NAME/Dockerfile | cut -d '"' -f 2)
-    - DISTRO_CODENAME=$(grep 'DISTRO_CODENAME' dockerfiles/$IMAGE_NAME/Dockerfile | cut -d '"' -f 2)
+    - RUST_STABLE_VERSION=$(grep 'RUST_STABLE_VERSION' dockerfiles/$IMAGE_NAME/Dockerfile | head -n 1 | cut -d '"' -f 2)
+    - DISTRO_CODENAME=$(grep 'DISTRO_CODENAME' dockerfiles/$IMAGE_NAME/Dockerfile | head -n 1 | cut -d '"' -f 2)
     - TAG_TUPLE="${DISTRO_CODENAME}-${RUST_STABLE_VERSION}"
     - $BUILDAH_COMMAND build
         --format=docker

--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -1,0 +1,135 @@
+FROM docker.io/library/ubuntu:jammy-20230425
+
+
+### meta ###
+
+ARG DISTRO_CODENAME="jammy"
+ARG RUST_STABLE_VERSION="1.69.0"
+ARG RUST_NIGHTLY_VERSION="2022-11-16"
+ARG LLVM_VERSION="15"
+ARG MINIO_VERSION="2023-04-06T16-51-10Z"
+
+WORKDIR /builds
+
+ENV SHELL=/bin/bash \
+    DEBIAN_FRONTEND=noninteractive \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    CC=clang-${LLVM_VERSION} \
+    CXX=clang-${LLVM_VERSION} \
+    RUST_BACKTRACE=1
+
+
+### base ###
+
+
+# base | add non-root user
+RUN groupadd -g 1000 nonroot && \
+    useradd -u 1000 -g 1000 -s /bin/bash -m nonroot
+
+# base | customize cargo configuration
+COPY ci-unified/cargo-config /root/.cargo/config
+COPY ci-unified/cargo-config /home/nonroot/.cargo/config
+
+# base | install tools and dependencies
+RUN set -eux; \
+    apt-get -y update; \
+    apt-get install -y --no-install-recommends \
+        libssl-dev make cmake graphviz \
+        git pkg-config curl wget time rhash ca-certificates jq \
+        python3 python3-pip lsof ruby ruby-bundler git-restore-mtime \
+        xz-utils zstd unzip gnupg protobuf-compiler && \
+
+# base | add llvm repo, clang and dependencies
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    echo "deb http://apt.llvm.org/${DISTRO_CODENAME}/ llvm-toolchain-${DISTRO_CODENAME}-${LLVM_VERSION} main" >> /etc/apt/sources.list.d/llvm-toochain-${DISTRO_CODENAME}-${LLVM_VERSION}.list; \
+    echo "deb-src http://apt.llvm.org/${DISTRO_CODENAME}/ llvm-toolchain-${DISTRO_CODENAME}-${LLVM_VERSION} main" >> /etc/apt/sources.list.d/llvm-toochain-${DISTRO_CODENAME}-${LLVM_VERSION}.list; \
+    apt-get -y update; \
+    apt-get install -y --no-install-recommends \
+        clang-${LLVM_VERSION} lldb-${LLVM_VERSION} lld-${LLVM_VERSION} libclang-${LLVM_VERSION}-dev && \
+
+# base | replace REPLACEME in the cargo configs with the real llvm version
+    sed -i "s/REPLACEME/${LLVM_VERSION}/g" /root/.cargo/config && \
+    sed -i "s/REPLACEME/${LLVM_VERSION}/g" /home/nonroot/.cargo/config && \
+
+# base | install specific minio client version (2023-04-06)
+    curl -L "https://dl.min.io/client/mc/release/linux-amd64/archive/mc.${MINIO_VERSION}" -o /usr/local/bin/mc && \
+    chmod 755 /usr/local/bin/mc && \
+
+# base | set a link to clang
+    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-${LLVM_VERSION} 100 && \
+
+# base | set a link to ldd
+    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-${LLVM_VERSION} 100 && \
+
+# base | install rustup, use minimum components
+    curl -L "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
+         -o rustup-init && \
+    chmod u+x rustup-init && \
+    ./rustup-init -y --no-modify-path --default-toolchain none && \
+    rm -f rustup-init && \
+    chown -R root:nonroot ${RUSTUP_HOME} ${CARGO_HOME} && \
+    chmod -R g+w ${RUSTUP_HOME} ${CARGO_HOME} && \
+
+# base | install python tools
+    pip install yq
+
+
+### generic ci ####
+
+
+# generic ci | install stable rust
+RUN set -eux && \
+    rustup toolchain install "${RUST_STABLE_VERSION}" --profile minimal && \
+    rustup default "${RUST_STABLE_VERSION}" && \
+
+# generic ci | "alias" pinned stable toolchain as generic stable
+    ln -s "/usr/local/rustup/toolchains/${RUST_STABLE_VERSION}-x86_64-unknown-linux-gnu" /usr/local/rustup/toolchains/stable-x86_64-unknown-linux-gnu && \
+
+# generic ci | install additional rustup components for the ci tests
+    rustup component add rust-src rustfmt clippy && \
+
+# generic ci | install specific rust nightly, default is stable, use minimum components
+    rustup toolchain install "nightly-${RUST_NIGHTLY_VERSION}" --profile minimal --component rustfmt && \
+
+# generic ci | "alias" pinned nightly toolchain as generic nightly
+    ln -s "/usr/local/rustup/toolchains/nightly-${RUST_NIGHTLY_VERSION}-x86_64-unknown-linux-gnu" /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+
+# generic ci | install wasm toolchain for the default stable toolchain
+    rustup target add wasm32-unknown-unknown && \
+
+# generic ci | install cargo tools
+    cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-hack \
+                  mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed && \
+    cargo install cargo-nextest --locked && \
+
+# generic ci | diener 0.4.6 | NOTE: before upgrading please test new version with companion build, example can be found here: https://github.com/paritytech/substrate/pull/12710
+    cargo install diener --version 0.4.6 && \
+
+# generic ci | wasm-bindgen-cli version should match the one pinned in substrate
+    cargo install --version 0.2.73 wasm-bindgen-cli && \
+
+# generic ci | install wasm-gc. useful for stripping slimming down wasm binaries
+    cargo install wasm-gc && \
+
+# generic ci | install cargo hfuzz and honggfuzz dependencies
+    apt-get -y update && \
+    apt-get install -y binutils-dev libunwind-dev libblocksruntime-dev && \
+    cargo install honggfuzz
+
+
+### finalize ###
+
+
+# finalize | versions
+RUN rustup show && \
+    cargo --version && \
+
+# finalize | cargo clean up, removes compilation artifacts cargo install creates (>250M)
+    rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache/sccache && \
+
+# finalize | apt clean up
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -73,14 +73,13 @@ RUN set -eux; \
     chmod -R g+w ${RUSTUP_HOME} ${CARGO_HOME} && \
 
 # base | install python tools
-    pip install yq
+    pip install yq && \
 
 
 ### generic ci ####
 
 
 # generic ci | install stable rust
-RUN set -eux && \
     rustup toolchain install "${RUST_STABLE_VERSION}" --profile minimal && \
     rustup default "${RUST_STABLE_VERSION}" && \
 
@@ -116,14 +115,14 @@ RUN set -eux && \
 # generic ci | install cargo hfuzz and honggfuzz dependencies
     apt-get -y update && \
     apt-get install -y binutils-dev libunwind-dev libblocksruntime-dev && \
-    cargo install honggfuzz
+    cargo install honggfuzz && \
 
 
 ### finalize ###
 
 
 # finalize | versions
-RUN rustup show && \
+    rustup show && \
     cargo --version && \
 
 # finalize | cargo clean up, removes compilation artifacts cargo install creates (>250M)

--- a/dockerfiles/ci-unified/README.md
+++ b/dockerfiles/ci-unified/README.md
@@ -1,0 +1,14 @@
+# The unified Parity CI image
+
+This image is used for running CI jobs for Parity repositories. Currently in the testing phrase, it will be used for most of the repositories in the future.
+
+### Specification
+
+The image is based on the latest Ubuntu LTS (`22.04` aka `jammy`) and contains the following:
+
+* Rust stable 1.69.0
+* Rust nightly 2022-11-16
+* LLVM 15
+* Python 3.10
+* Ruby 3.0
+* Plenty of different utilities required in the CI pipelines

--- a/dockerfiles/ci-unified/cargo-config
+++ b/dockerfiles/ci-unified/cargo-config
@@ -1,0 +1,9 @@
+[target.wasm32-unknown-unknown]
+# use clang as linker
+linker="clang-REPLACEME"
+
+[target.x86_64-unknown-linux-gnu]
+# use clang as linker
+linker="clang-REPLACEME"
+# enable the additional instruction extensions for rustcrypto deps
+rustflags = ["-Ctarget-feature=+aes,+sse2,+ssse3"]


### PR DESCRIPTION
I want to try to gradually replace all our CI images with a single one that is built from the single source of truth, tagged as `<distro codename>-<rust version>`, plus an additional `<distro codename>` tag. I don't think that image size matters, if we'll also push the image to our internal registry located closely to the CI runners or just start proxying the Docker Hub upstream.

What this PR introduces right now:
* New `ci-unified` image that combines `base-ci-linux` and `ci-linux` (will absorb other images later)
* Bump the base image to Ubuntu 22.04 (needed for my Firebuild tests, could be downgraded back to `stretch` if there will be no success with Firebuild)
* Bump LLVM to 15 and allow upping its version via a single change to the relevant `ARG`
* Pin stable Rust to bump it explicitly in the future cases when needed
* Use consistent Dockerfile formatting
* Build the image on beefy `docker+machine` runners