### PR TITLE
Fix broken `changes:` behavior

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -189,10 +189,6 @@ mdbook-utils-pr:
   <<: *docker_build_pr
   variables:
     IMAGE_NAME:                    "mdbook-utils"
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-      changes:
-        - dockerfiles/mdbook-utils/**
 
 mitogen-pr:
   <<: *docker_build_pr
@@ -294,7 +290,9 @@ releng-scripts-download-pr:
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       changes:
-        - dockerfiles/releng-scripts/**
+        paths:
+          - dockerfiles/${IMAGE_NAME}/**
+        compare_to: 'master'
   script:
     - mkdir -p artifacts/
     - cd artifacts/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,7 +117,9 @@ default:
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       changes:
-        - dockerfiles/${IMAGE_NAME}/**
+        paths:
+          - dockerfiles/${IMAGE_NAME}/**
+        compare_to: 'master'
   script:
     - *docker_build_only
   tags:

--- a/dockerfiles/lz4/README.md
+++ b/dockerfiles/lz4/README.md
@@ -1,1 +1,2 @@
 # Image containing lz4 and wget binaries.
+

--- a/dockerfiles/lz4/README.md
+++ b/dockerfiles/lz4/README.md
@@ -1,2 +1,1 @@
 # Image containing lz4 and wget binaries.
-


### PR DESCRIPTION
`changes:` in the `.docker_build_pr` hidden job wasn't working properly, resulting in creating `.docker_build_pr` templated job for each defined image which gave tremendous overhead. This PR fixes that.