### PR TITLE
Use date versioning for `ci-unified`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -360,12 +360,14 @@ ci-unified:
     - RUST_STABLE_VERSION=$(grep 'RUST_STABLE_VERSION' dockerfiles/$IMAGE_NAME/Dockerfile | head -n 1 | cut -d '"' -f 2)
     - DISTRO_CODENAME=$(grep 'DISTRO_CODENAME' dockerfiles/$IMAGE_NAME/Dockerfile | head -n 1 | cut -d '"' -f 2)
     - TAG_TUPLE="${DISTRO_CODENAME}-${RUST_STABLE_VERSION}"
+    - DATESTAMP=$(git log -1 --pretty=format:"%ad" --date=format:"%Y%m%d" -- dockerfiles/$IMAGE_NAME/Dockerfile)
     - $BUILDAH_COMMAND build
         --format=docker
         --build-arg VCS_REF="$CI_COMMIT_SHA"
         --build-arg BUILD_DATE="$(date +%Y%m%d)"
         --build-arg REGISTRY_PATH="$REGISTRY_PATH"
         --tag "$REGISTRY_PATH/$IMAGE_NAME:$TAG_TUPLE"
+        --tag "$REGISTRY_PATH/$IMAGE_NAME:$TAG_TUPLE-v$DATESTAMP"
         --tag "$REGISTRY_PATH/$IMAGE_NAME:$DISTRO_CODENAME"
         --file "dockerfiles/$IMAGE_NAME/Dockerfile" dockerfiles
     - $BUILDAH_COMMAND info
@@ -373,6 +375,7 @@ ci-unified:
         buildah login --username "$Docker_Hub_User_Parity" --password-stdin "$REGISTRY_NAME"
     - $BUILDAH_COMMAND push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$TAG_TUPLE"
     - $BUILDAH_COMMAND push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$DISTRO_CODENAME"
+    - $BUILDAH_COMMAND push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:$DISTRO_CODENAME-v$DATESTAMP"
     - buildah logout "$REGISTRY_NAME"
   tags:
     - linux-docker-vm-c2


### PR DESCRIPTION
Note that instead of e.g. random `$CI_COMMIT_SHA` and its friends, this one actually picks a date when the relevant Dockerfile was changed and nothing else.