### PR TITLE
debian 11 docker image was added

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -405,6 +405,11 @@ debian10:
   script:
     - *push_to_docker_hub
 
+debian11:
+  <<:                              *docker_build
+  script:
+    - *push_to_docker_hub
+
 github-gh-cli:
   <<:                              *docker_build
   script:
@@ -973,6 +978,12 @@ publish-debian10-docker-image-description:
   variables:
     IMAGE_NAME:           debian10
     SHORT_DESCRIPTION:    "debian10 utility Docker image."
+
+publish-debian11-docker-image-description:
+  extends:                .publish-docker-image-description
+  variables:
+    IMAGE_NAME:           debian11
+    SHORT_DESCRIPTION:    "debian11 utility Docker image."
 
 publish-gnupg-docker-image-description:
   extends:                .publish-docker-image-description

--- a/dockerfiles/debian11/Dockerfile
+++ b/dockerfiles/debian11/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:bullseye
+
+# metadata
+ARG VCS_REF=master
+ARG BUILD_DATE=""
+ARG REGISTRY_PATH=docker.io/paritytech
+LABEL io.parity.image.authors="devops-team@parity.io" \
+        io.parity.image.vendor="Parity Technologies" \
+        io.parity.image.title="${REGISTRY_PATH}/debian11" \
+        io.parity.image.description="ansible" \
+        io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/debian11/Dockerfile" \
+        io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
+dockerfiles/debian11/README.md" \
+        io.parity.image.revision="${VCS_REF}" \
+        io.parity.image.created="${BUILD_DATE}"
+
+
+ARG DEBIAN_FRONTEND=noninteractive
+# Install dependencies.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       sudo systemd systemd-sysv \
+       build-essential wget libffi-dev libssl-dev \
+       python3-pip python3-dev python3-setuptools python3-wheel python3-apt \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
+# Make sure systemd doesn't start agettys on tty[1-6].
+RUN rm -f /lib/systemd/system/multi-user.target.wants/getty.target
+CMD ["/lib/systemd/systemd"]

--- a/dockerfiles/debian11/README.md
+++ b/dockerfiles/debian11/README.md
@@ -1,0 +1,4 @@
+# Description
+
+This Debian 10 image is used in the ansible Molecule test as a base to apply roles.
+The docker image should be close to default GCP or AWS images.

--- a/dockerfiles/debian11/README.md
+++ b/dockerfiles/debian11/README.md
@@ -1,4 +1,4 @@
 # Description
 
-This Debian 10 image is used in the ansible Molecule test as a base to apply roles.
+This Debian 11 image is used in the ansible Molecule test as a base to apply roles.
 The docker image should be close to default GCP or AWS images.


### PR DESCRIPTION
The debian 11 docker image was added because we need it to run new versions of node binaries.