### PR TITLE
Install wasm target into nightly toolchain

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -22,12 +22,14 @@ LABEL summary="Image for Substrate-based projects." \
 RUN set -eux && \
 	# install `rust-src` component for ui test
 	rustup component add rust-src rustfmt clippy && \
+	# install wasm target into default (stable) toolchain
+	rustup target add wasm32-unknown-unknown && \
 	# install specific Rust nightly, default is stable, use minimum components
 	rustup toolchain install "nightly-${RUST_NIGHTLY}" --profile minimal --component rustfmt && \
+	# install wasm target into nightly toolchain
+	rustup target add wasm32-unknown-unknown --toolchain "nightly-${RUST_NIGHTLY}" && \
 	# "alias" pinned nightly toolchain as nightly
 	ln -s "/usr/local/rustup/toolchains/nightly-${RUST_NIGHTLY}-x86_64-unknown-linux-gnu" /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
-	# install wasm toolchain
-	rustup target add wasm32-unknown-unknown && \
 	# install cargo tools
 	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-hack \
 	  mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed && \


### PR DESCRIPTION
Projects with substrate version less than 0.9.42 need wasm target installed into nightly toolchain. Though a project itself can be built on stable, the wasm-builder [searches](https://github.com/paritytech/substrate/blob/98f2e3451c9143278ec53c6718940aeabcd3b68a/utils/wasm-builder/src/lib.rs#L208) for the latest nightly toolchain with wasm target programmatically. It was fixed [here](https://github.com/paritytech/substrate/pull/13580) and released only in 0.9.42, so all versions before that need to have a nightly (even not active) toolchain with wasm target installed.

We are currently facing an issue with benchmarking Trappist via command bot. Trappist is built on v0.9.37. There are other projects suffering from this as well.