### PR TITLE
Explicitly replace ssh package by ssh-client in Docker images

### DIFF
--- a/dockerfiles/ansible/Dockerfile
+++ b/dockerfiles/ansible/Dockerfile
@@ -18,7 +18,7 @@ dockerfiles/ansible/README.md" \
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    sshpass ssh rsync tini curl git ruby
+    sshpass ssh-client rsync tini curl git ruby
 
 RUN pip install pip --upgrade
 RUN pip install ansible

--- a/dockerfiles/mitogen/Dockerfile
+++ b/dockerfiles/mitogen/Dockerfile
@@ -18,7 +18,7 @@ dockerfiles/mitogen/README.md" \
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    sshpass ssh rsync tini curl git ruby \
+    sshpass ssh-client rsync tini curl git ruby \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir pip --upgrade

--- a/dockerfiles/tools/Dockerfile
+++ b/dockerfiles/tools/Dockerfile
@@ -10,7 +10,7 @@ ENV PROM_VERSION=2.19.0
 LABEL io.parity.image.authors="devops-team@parity.io" \
 	io.parity.image.vendor="Parity Technologies" \
 	io.parity.image.title="${REGISTRY_PATH}/tools" \
-	io.parity.image.description="curl git jq rsync make gettext gnupg bash shadow redis promtool openssh ruby" \
+	io.parity.image.description="curl git jq rsync make gettext gnupg bash shadow redis promtool openssh-client ruby" \
 	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
 dockerfiles/tools/Dockerfile" \
 	io.parity.image.documentation="https://github.com/paritytech/scripts/blob/${VCS_REF}/\
@@ -19,7 +19,7 @@ dockerfiles/tools/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 
-RUN apk add --no-cache curl git jq rsync make gettext gnupg bash shadow redis openssh ruby xz ripgrep zstd skopeo
+RUN apk add --no-cache curl git jq rsync make gettext gnupg bash shadow redis openssh-client ruby xz ripgrep zstd skopeo
 
 RUN curl -L "https://dl.min.io/client/mc/release/linux-amd64/mc" -o /usr/local/bin/mc && chmod 755 /usr/local/bin/mc
 


### PR DESCRIPTION
**What does this change do and why is it necessary?**  

Installation of a generic `ssh` package also pulls `ssh-server` as well as initially assumed `ssh-client`. While `ssh-server` is not actually used in the containers, all of the instances share the same ssh server key inside the container filesystem. This approach may produce security issues in the future, if someone runs and relies on the ssh server, inherited from such images.

Now, this can lead to false-positives from security scanners and to increasing the size of the image. 
