### PR TITLE
`ink-ci-linux` fix stable toolchain to `1.69`

### DIFF
--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -50,14 +50,12 @@ RUN set -eux; \
 	# `RUSTC_BOOSTRAP=1` environment variable. We also need to install the
 	# `wasm32-unknown-unknown` target since that's the platform that ink! smart contracts
 	# run on.
-	rustup target add wasm32-unknown-unknown --toolchain stable && \
-	rustup component add rust-src clippy rustfmt --toolchain stable && \
-	rustup default stable && \
-
-    # The 1.69 toolchain is temporarily required to build ink! contracts because of \
+    #
+    # The 1.69 toolchain is temporarily required to build ink! contracts because of
     # https://github.com/paritytech/cargo-contract/issues/1139
-    rustup target add wasm32-unknown-unknown --toolchain 1.69 && \
-    rustup component add rust-src clippy rustfmt --toolchain 1.69 && \
+	rustup target add wasm32-unknown-unknown --toolchain 1.69 && \
+	rustup component add rust-src clippy rustfmt --toolchain 1.69 && \
+	rustup default 1.69 && \
 
 	# We also use the nightly toolchain to lint ink!. We perform checks using RustFmt,
 	# Cargo Clippy, and Miri.

--- a/dockerfiles/ink-ci-linux/Dockerfile
+++ b/dockerfiles/ink-ci-linux/Dockerfile
@@ -54,6 +54,11 @@ RUN set -eux; \
 	rustup component add rust-src clippy rustfmt --toolchain stable && \
 	rustup default stable && \
 
+    # The 1.69 toolchain is temporarily required to build ink! contracts because of \
+    # https://github.com/paritytech/cargo-contract/issues/1139
+    rustup target add wasm32-unknown-unknown --toolchain 1.69 && \
+    rustup component add rust-src clippy rustfmt --toolchain 1.69 && \
+
 	# We also use the nightly toolchain to lint ink!. We perform checks using RustFmt,
 	# Cargo Clippy, and Miri.
 	#


### PR DESCRIPTION
`1.70` can now generate the wasm `sign-ext` instruction which will fail to build with `cargo-contract` and fail to execute with `pallet-contracts`, See https://github.com/paritytech/cargo-contract/issues/1139