### PR TITLE
Downgrade rust nightly version

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -4,7 +4,7 @@ ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/base-ci-linux:latest
 
-ARG RUST_NIGHTLY="2023-05-23"
+ARG RUST_NIGHTLY="2023-01-01"
 
 # metadata
 LABEL summary="Image for Substrate-based projects." \


### PR DESCRIPTION
There is a [known problem](https://stackoverflow.com/questions/75955457/substrate-node-template-cannot-create-a-runtime-error-othercannot-deserialize) with wasm compilation on the latest rust nightly. For example, [this job](https://gitlab.parity.io/parity/mirrors/trappist/-/jobs/2959599) currently fails with `cannot deserialize module: UnknownOpcode(192)`. 

Version `2023-01-01` is known to work.

