### PR TITLE
feat(ci-linux): bundle second nightly just for rustfmt

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -5,6 +5,7 @@ ARG REGISTRY_PATH=docker.io/paritytech
 FROM ${REGISTRY_PATH}/base-ci-linux:latest
 
 ARG RUST_NIGHTLY="2023-01-01"
+ARG RUST_NIGHTLY_FMT="2023-05-23"
 
 # metadata
 LABEL summary="Image for Substrate-based projects." \
@@ -30,6 +31,10 @@ RUN set -eux && \
 	rustup target add wasm32-unknown-unknown --toolchain "nightly-${RUST_NIGHTLY}" && \
 	# "alias" pinned nightly toolchain as nightly
 	ln -s "/usr/local/rustup/toolchains/nightly-${RUST_NIGHTLY}-x86_64-unknown-linux-gnu" /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu && \
+	# install dedicated Rust nightly to be used just for rustfmt
+	rustup toolchain install "nightly-${RUST_NIGHTLY_FMT}" --profile minimal --component rustfmt && \
+	# "alias" pinned nightly toolchain as nightly-fmt
+	ln -s "/usr/local/rustup/toolchains/nightly-${RUST_NIGHTLY_FMT}-x86_64-unknown-linux-gnu" /usr/local/rustup/toolchains/nightly-fmt-x86_64-unknown-linux-gnu && \
 	# install cargo tools
 	cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-hack \
 	  mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-last-changed && \


### PR DESCRIPTION
This way we can use different nightlies for rustfmt and wasm compilation.