### PR TITLE
Revert "Downgrade rust nightly version (#570)"

### DIFF
--- a/dockerfiles/ci-linux/Dockerfile
+++ b/dockerfiles/ci-linux/Dockerfile
@@ -4,7 +4,7 @@ ARG REGISTRY_PATH=docker.io/paritytech
 
 FROM ${REGISTRY_PATH}/base-ci-linux:latest
 
-ARG RUST_NIGHTLY="2023-01-01"
+ARG RUST_NIGHTLY="2023-05-23"
 
 # metadata
 LABEL summary="Image for Substrate-based projects." \


### PR DESCRIPTION
This reverts commit d635ef2f071446216371bc36db43b0112bc8397d.

The trappist team has indicated they no longer need us to provide an old nightly; they're simply installing one locally in their cmd-bot script: https://github.com/paritytech/command-bot-scripts/blob/1e8a2e9500af9884181c45fa85a09da0e2f3a53f/commands/bench/lib/bench-all-trappist.sh#L5