### PR TITLE
Always auto-retry `ci-unified` builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -398,6 +398,10 @@ ci-unified:
         $BUILDAH_COMMAND push --format=v2s2 "$REGISTRY_PATH/$IMAGE_NAME:latest"
       fi
     - buildah logout "$REGISTRY_NAME"
+  retry:
+    max: 2
+    when:
+      - always
   tags:
     - linux-docker-vm-c2
 


### PR DESCRIPTION
`script_failure` covers transient errors, which is included in `always`.