### PR TITLE
Remove some legacy `contracts` related stuff

### DIFF
--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -256,11 +256,9 @@ RUN	cargo install --git https://github.com/paritytech/ink-waterfall.git csv-comp
 ### parity-scale-codec ###
 
 # codecov from ink-ci-linux
-# `binaryen` from contracts-ci
 
 # parity-scale-codec
-RUN	cargo +nightly-${RUST_NIGHTLY_VERSION} install grcov rust-covfix xargo dylint-link && \
-	cargo +nightly-${RUST_NIGHTLY_VERSION} install cargo-contract --locked
+RUN	cargo +nightly-${RUST_NIGHTLY_VERSION} install grcov rust-covfix xargo dylint-link
 
 ### finalize ###
 

--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -125,14 +125,7 @@ RUN apt-get -y update && \
 
 RUN apt-get install -y --no-install-recommends \
         zlib1g-dev npm wabt && \
-	npm install --ignore-scripts -g yarn 
-
-# contracts ci 
-# `binaryen` is needed by `cargo-contract` for optimizing Wasm files.
-# We fetch the latest release which contains a Linux binary.
-RUN	curl -L $(curl --silent https://api.github.com/repos/WebAssembly/binaryen/releases \
-		 | jq -r '.[0].assets | [.[] | .browser_download_url] | map(select(match("x86_64-linux\\.tar\\.gz$"))) | .[0]' \
-		 ) | tar -xz -C /usr/local/bin/ --wildcards --strip-components=2 'binaryen-*/bin/wasm-opt'
+	npm install --ignore-scripts -g yarn
 
 # contracts ci 
 # We also use the nightly toolchain for linting. We perform checks using RustFmt, and
@@ -281,7 +274,6 @@ RUN rustup show && \
 	estuary --version && \
     # inc-ci-linux
     cargo-contract --version && \
-	wasm-opt --version && \
     # ink-waterfall-ci
     substrate-contracts-node-rand-extension --version
 


### PR DESCRIPTION
1. remove `binaryen` tools incl. `wasm-opt`, since `cargo-contract` uses the embedded lib now. **Assumes no other projects are using it**
2. remove second installation of `cargo-contract` from `crates.io` installed using nightly toolchain? Perhaps a legacy thing, but `cargo-contract` is already installed earlier [here](https://github.com/paritytech/scripts/blob/d96a16e2f92ee76fe4b9241475ea3e2c1da648a0/dockerfiles/ci-unified/Dockerfile#L147), and we no longer build with `nightly`.

