### PR TITLE
Add new base image: `base-bin`

### DIFF
--- a/dockerfiles/base-bin/Dockerfile
+++ b/dockerfiles/base-bin/Dockerfile
@@ -1,0 +1,43 @@
+FROM docker.io/library/ubuntu:22.04
+
+# metadata
+ARG VCS_REF
+ARG BUILD_DATE
+ARG GPG_KEYSERVER="keyserver.ubuntu.com"
+ARG PARITY_SEC_GPGKEY=9D4B2B6EB8F97156D19669A9FF0812D491B96798
+ARG DOC_URL=https://github.com/paritytech/polkadot
+ARG USER=parity
+
+LABEL io.parity.image.authors="devops-team@parity.io" \
+	io.parity.image.vendor="Parity Technologies" \
+	io.parity.image.title="parity/base-bin" \
+	io.parity.image.description="A base image for standard binary distribution" \
+	io.parity.image.source="https://github.com/paritytech/scripts/blob/${VCS_REF}/dockerfiles/base-bin/Dockerfile" \
+	io.parity.image.revision="${VCS_REF}" \
+	io.parity.image.created="${BUILD_DATE}" \
+	io.parity.image.documentation="${DOC_URL}"
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+
+# install tools and dependencies
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		libssl3 ca-certificates gnupg && \
+	useradd -m -u 1000 -U -s /bin/sh -d /${USER} ${USER} && \
+# add repo's gpg keys and install the published polkadot binary
+	gpg --keyserver ${GPG_KEYSERVER} --recv-keys ${PARITY_SEC_GPGKEY} && \
+	gpg --export ${PARITY_SEC_GPGKEY} > /usr/share/keyrings/parity.gpg && \
+	echo 'deb [signed-by=/usr/share/keyrings/parity.gpg] https://releases.parity.io/deb release main' > /etc/apt/sources.list.d/parity.list && \
+	apt-get update && \
+# apt cleanup
+	apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* ; \
+	mkdir -p /data /${USER}/.local/share && \
+	chown -R ${USER}:${USER} /data && \
+	ln -s /data /${USER}/.local/share/${USER}
+
+# Set last update
+ENV TMSP=/var/lastupdate
+RUN	mkdir -p $(dirname $TMSP); date > $TMSP; chmod a+r $TMSP
+
+USER ${USER}

--- a/dockerfiles/base-bin/README.md
+++ b/dockerfiles/base-bin/README.md
@@ -1,0 +1,13 @@
+# `base-bin``
+
+A frequently built and updated image to be used as base for our binary distribution.
+The image is not named after a specific distribution such as `ubuntu` to leave us the option
+to change the base image over time.
+
+This base image is Parity opinionated and contains our GPG keys.
+
+Unlike the `base-ci-linux` image which contain development toolchains, this image is meant to be used as base image for final delivery of binaries.
+
+## Build
+
+See `./build.sh`

--- a/dockerfiles/base-bin/build.sh
+++ b/dockerfiles/base-bin/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+ENGINE=podman
+IMAGE=parity/base-bin
+REGISTRY=${REGISTRY:-docker.io}
+
+$ENGINE build \
+    --build-arg BUILD_DATE=$(date +%Y%m%d) \
+    --build-arg USER=parity \
+    -t $REGISTRY/parity/$IMAGE \
+    -t $REGISTRY/$USER/$IMAGE \
+    -t $REGISTRY/$IMAGE \
+    .
+$ENGINE images | grep $IMAGE
+$ENGINE run --rm -it -h $IMAGE $IMAGE bash -c 'uname -a; echo "Last updated:"; cat /var/lastupdate'


### PR DESCRIPTION
## Context

The number of binaries distributed via Container images is increasing.
We have a base image dedicated to CI but there is so far no base image intended to the standard distribution of our binaries. As a result, each of our release images contain the same duplicated code:
- add parity GPG keys
- run an apt update
- create a user
- symlink a data folder
- etc...

Most our images are based on the an updated version of a base image (ubuntu:20.04 atm).
However, those images are built and published without having kinda of chance for any testing.

Building the image from this PR nighlty gives us the option to run some secruity testing / auditing on the base image before using it in production.

This PR does not include security/auditing of the built image.

Once a build of this image is available, all our polkadot, cumulus, staking-miner, etc... can be rebuilt with this new base image. it will cut the build time and offer a reliable and common base.

## Todo

- [ ] Add nightly scheduled build

## References

- https://github.com/paritytech/release-engineering/issues/97
