### PR TITLE
Revert spaces fix

### DIFF
--- a/dockerfiles/terraform/Dockerfile
+++ b/dockerfiles/terraform/Dockerfile
@@ -22,13 +22,13 @@ RUN apk add --no-cache \
 		ca-certificates git jq make curl gettext bash shadow openssh-client; \
 	curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
 		-o terraform.zip; \
-	unzip terraform.zip	-d /usr/local/bin/terraform; \
+	unzip terraform.zip	-d /usr/local/bin/ terraform; \
 	rm terraform.zip; \
 	chmod +x /usr/local/bin/terraform
 
 RUN	curl "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" \
 		-o vault.zip; \
-	unzip vault.zip	-d /usr/local/bin/vault; \
+	unzip vault.zip	-d /usr/local/bin/ vault; \
 	rm vault.zip; \
 	chmod +x /usr/local/bin/vault
 


### PR DESCRIPTION
[This ](https://github.com/paritytech/scripts/commit/a0e304ff984cf6427b0bb4aa929662cbd3b5b782) Broke terraform and vault being accessible from PATH, I'm not sure what the previous change was trying to fix.