### PR TITLE
[substrate-session-keys-grabber] Add beefy support

### DIFF
--- a/dockerfiles/substrate-session-keys-grabber/grabber.py
+++ b/dockerfiles/substrate-session-keys-grabber/grabber.py
@@ -17,6 +17,7 @@ def parse_session_key(dir):
   key_formats = (
     ['6772616e', '62616265', '696d6f6e', '70617261', '61756469'], # validator keys (gran,babe,imon,para,audi)
     ['6772616e', '62616265', '696d6f6e', '70617261', '6173676e', '61756469'], # validator keys (gran,babe,imon,para,asgn,audi)
+    ['6772616e', '62616265', '696d6f6e', '70617261', '6173676e', '61756469', '62656566'], # validator keys (gran,babe,imon,para,asgn,audi,beef)
     ['61757261'] # collator keys (aura)
     )
   possible_prefixes = list(set([j for i in key_formats for j in i]))


### PR DESCRIPTION
New session key also contains beefy key