### PR TITLE
Update rve toolchain in unified image

### DIFF
--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -104,10 +104,10 @@ RUN ln -s "/usr/local/rustup/toolchains/nightly-${RUST_NIGHTLY_VERSION}-x86_64-u
 RUN rustup target add wasm32-unknown-unknown
 
 # Install rve-nightly-2023-04-05
-RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu/rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
-    tar --zstd -xf rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
-    cd rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu && \
-    mv tmp/rve-nightly ~/.rustup/toolchains && \
+
+RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu/rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
+    tar --zstd -xf rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
+    mv tmp/rve-nightly /usr/local/rustup/toolchains && \
     rm -f rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
     rmdir tmp
 

--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -104,13 +104,12 @@ RUN ln -s "/usr/local/rustup/toolchains/nightly-${RUST_NIGHTLY_VERSION}-x86_64-u
 RUN rustup target add wasm32-unknown-unknown
 
 # Install rve-nightly-2023-04-05
-RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu/rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz && \
-    tar xfz rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz && \
+RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu/rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
+    tar --zstd -xf rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
     cd rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu && \
-    ./install.sh -f && \
-    cd .. && \
-    rm -f rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz && \
-    rm -rf rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu
+    mv tmp/rve-nightly ~/.rustup/toolchains && \
+    rm -f rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
+    rmdir tmp
 
 # rve-nightly-2023-04-05 requires a newer version of openssl
 RUN echo "deb http://deb.debian.org/debian unstable main non-free contrib" >> /etc/apt/sources.list && \

--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -103,18 +103,6 @@ RUN ln -s "/usr/local/rustup/toolchains/nightly-${RUST_NIGHTLY_VERSION}-x86_64-u
 # generic ci | install wasm toolchain for the default stable toolchain
 RUN rustup target add wasm32-unknown-unknown
 
-# Install rve-nightly-2023-04-05
-
-RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu/rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
-    tar --zstd -xf rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
-    mv tmp/rve-nightly /usr/local/rustup/toolchains && \
-    rm -f rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
-    rmdir tmp
-
-# rve-nightly-2023-04-05 requires a newer version of openssl
-RUN echo "deb http://deb.debian.org/debian unstable main non-free contrib" >> /etc/apt/sources.list && \
-    apt update && apt-get install -y openssl
-
 # generic ci | install x86_64 musl toolchain for the default stable toolchain
 RUN apt-get install -y --no-install-recommends g++
 RUN rustup target add x86_64-unknown-linux-musl
@@ -286,6 +274,18 @@ RUN	cargo install --git https://github.com/paritytech/ink-waterfall.git csv-comp
 
 # parity-scale-codec
 RUN	cargo +nightly-${RUST_NIGHTLY_VERSION} install grcov rust-covfix xargo dylint-link
+
+# Install rve-nightly-2023-04-05
+
+RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu/rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
+    tar --zstd -xf rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
+    mv tmp/rve-nightly /usr/local/rustup/toolchains && \
+    rm -f rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
+    rmdir tmp
+
+# rve-nightly-2023-04-05 requires a newer version of openssl
+RUN echo "deb http://deb.debian.org/debian unstable main non-free contrib" >> /etc/apt/sources.list && \
+    apt update && apt-get install -y openssl
 
 ### finalize ###
 

--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -120,10 +120,10 @@ RUN apt-get install -y --no-install-recommends g++
 RUN rustup target add x86_64-unknown-linux-musl
 
 # generic ci | install common cargo tools
-RUN cargo install cargo-web wasm-pack cargo-deny cargo-spellcheck cargo-hack \
+RUN cargo install cargo-web wasm-pack cargo-deny cargo-hack \
                   mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-admonish mdbook-last-changed
 
-RUN cargo install cargo-nextest --locked
+RUN cargo install cargo-spellcheck cargo-nextest --locked
 
 # generic ci | diener 0.4.6 | NOTE: before upgrading please test new version with companion build, example can be found here: https://github.com/paritytech/substrate/pull/12710
 RUN cargo install diener --version 0.4.6

--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -103,11 +103,18 @@ RUN ln -s "/usr/local/rustup/toolchains/nightly-${RUST_NIGHTLY_VERSION}-x86_64-u
 # generic ci | install wasm toolchain for the default stable toolchain
 RUN rustup target add wasm32-unknown-unknown
 
-# Install rv32e-nightly-2023-04-05
-RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-riscv32em-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu/rust-riscv32em-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz
-RUN tar xfz rust-riscv32em-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz
-RUN mv rust-riscv32em-x86_64-unknown-linux-gnu/riscv32em-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu/ /usr/local/rustup/toolchains
-RUN rm -f rust-riscv32em-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz
+# Install rve-nightly-2023-04-05
+RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu/rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz && \
+    tar xfz rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz && \
+    cd rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu && \
+    ./install.sh -f && \
+    cd .. && \
+    rm -f rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.xz && \
+    rm -rf rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu
+
+# rve-nightly-2023-04-05 requires a newer version of openssl
+RUN echo "deb http://deb.debian.org/debian unstable main non-free contrib" >> /etc/apt/sources.list && \
+    apt update && apt-get install -y openssl
 
 # generic ci | install x86_64 musl toolchain for the default stable toolchain
 RUN apt-get install -y --no-install-recommends g++

--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -280,7 +280,7 @@ RUN	cargo +nightly-${RUST_NIGHTLY_VERSION} install grcov rust-covfix xargo dylin
 RUN wget https://github.com/paritytech/rustc-rv32e-toolchain/releases/download/rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu/rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
     tar --zstd -xf rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
     mv tmp/rve-nightly /usr/local/rustup/toolchains && \
-    rm -f rust-rve-nightly-2023-04-05-r0-x86_64-unknown-linux-gnu.tar.zst && \
+    rm -f rust-rve-nightly-2023-04-05-x86_64-unknown-linux-gnu.tar.zst && \
     rmdir tmp
 
 # rve-nightly-2023-04-05 requires a newer version of openssl


### PR DESCRIPTION
Update the unified-ci script with the latest version of the risc-v toolchain and openssl to version 3.1.4
