### PR TITLE
Use @polkadot/api-cli@0.56.2 node package to build paritytech/polkadotjs-cli

### DIFF
--- a/dockerfiles/polkadotjs-cli/Dockerfile
+++ b/dockerfiles/polkadotjs-cli/Dockerfile
@@ -17,4 +17,4 @@ dockerfiles/polkadotjs-cli/README.md" \
 	io.parity.image.created="${BUILD_DATE}"
 
 RUN apk add --no-cache bash yarn npm jq wget && \
-    yarn global add @polkadot/api-cli
+    yarn global add @polkadot/api-cli@0.56.2


### PR DESCRIPTION
I'm not sure how to trigger new build for https://hub.docker.com/r/paritytech/polkadotjs-cli - IIUC I need to change the Dockerfile in some way, but there's nothing to change :) So I've changed the package version. If there's a better way - please suggest! Thank you!