### PR TITLE
Add `--locked` to `mdbook-graphviz` to fix build

### DIFF
--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -111,7 +111,7 @@ RUN rustup target add x86_64-unknown-linux-musl
 
 # generic ci | install common cargo tools
 RUN cargo install cargo-web wasm-pack cargo-deny cargo-hack \
-    mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-admonish mdbook-last-changed
+    mdbook mdbook-mermaid mdbook-linkcheck mdbook-graphviz mdbook-admonish mdbook-last-changed --locked
 
 RUN cargo install cargo-spellcheck cargo-nextest --locked
 


### PR DESCRIPTION
Build fails see https://gitlab.parity.io/parity/mirrors/scripts/-/jobs/5311307#L3923