### PR TITLE
optimize ws-health-exporter

### DIFF
--- a/dockerfiles/ws-health-exporter/README.md
+++ b/dockerfiles/ws-health-exporter/README.md
@@ -18,7 +18,7 @@ It can be configured using environment variables:
   default `ws://127.0.0.1:5556`
 * `WSHE_NODE_MAX_UNSYNCHRONIZED_BLOCK_DRIFT` - setups maximum of unsynchronized blocks; if a node has
   more, the health check will fail; default `0` blocks (disabled)
-* `WSHE_NODE_MIN_PEERS` - setups minimum of peers; if a node has less, the health check will fail; default `10` peers
+* `WSHE_NODE_MIN_PEERS` - setups minimum of peers; if a node has less, the health check will fail; default `2` peers
 * `WSHE_BLOCK_RATE_MEASUREMENT_PERIOD` - average rate of new blocks is calculated for the period;
   if this period is less than `WSHE_WS_CHECK_INTERVAL` it will be equal `WSHE_WS_CHECK_INTERVAL`; 
   default `600` seconds

--- a/dockerfiles/ws-health-exporter/exporter.py
+++ b/dockerfiles/ws-health-exporter/exporter.py
@@ -18,6 +18,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from prometheus_client import generate_latest, Gauge
 from websocket import create_connection
 from environs import Env
+import signal
 
 LOGGING_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 
@@ -42,10 +43,16 @@ app_config = {
     'ws_timeout': 60, # WSHE_WS_TIMEOUT
     'node_rpc_urls': ['ws://127.0.0.1:5556'], # WSHE_NODE_RPC_URLS
     'node_max_unsynchronized_block_drift': 0, # WSHE_NODE_MAX_UNSYNCHRONIZED_BLOCK_DRIFT
-    'node_min_peers': 10, # WSHE_NODE_MIN_PEERS
+    'node_min_peers': 2, # WSHE_NODE_MIN_PEERS
     'block_rate_measurement_period': 600, # WSHE_BLOCK_RATE_MEASUREMENT_PERIOD
     'min_block_rate': 0.0, # WSHE_MIN_BLOCK_RATE
 }
+
+
+def handle_sigterm(signum, frame):
+    logging.info("Received SIGTERM. Shutting down...")
+    scheduler.shutdown()
+    sys.exit(0)
 
 
 def read_readiness_status():
@@ -201,6 +208,7 @@ def health_readiness():
 
 if __name__ == '__main__':
     global block_number_cache
+    signal.signal(signal.SIGTERM, handle_sigterm)
 
     parse_config(app_config)
 


### PR DESCRIPTION
Issue: https://github.com/paritytech/helm-charts/issues/330

When `ws-health-exporter` is used as a sidecar in Kubernetes, it adds a delay to the start and stop of the pod.

During startup, the node needs a couple of seconds to reach 10 peers. If we have 2 peers, it should be enough.

During shutdown, the container ignores the signal from Kubernetes, causing it to hang for another 30 seconds while the main container is dead.