### PR TITLE
update mitogen docker image

### DIFF
--- a/dockerfiles/mitogen/Dockerfile
+++ b/dockerfiles/mitogen/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update -y && \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir pip --upgrade
-RUN pip install --no-cache-dir ansible==5.10 google-auth requests jmespath
+RUN pip install --no-cache-dir ansible==5.10 google-auth requests jmespath dnspython
 
 RUN  curl -fSL -o /usr/local/bin/subkey 'https://releases.parity.io/substrate/x86_64-debian%3Astretch/v3.0.0/subkey/subkey' \
      && chmod +x /usr/local/bin/subkey


### PR DESCRIPTION
fix error:
```
An unhandled exception occurred while running the lookup plugin 'community.general.dig'. Error was a <class 'ansible.errors.AnsibleError'>, original message: The dig lookup requires the python 'dnspython' library and it is not installed. The dig lookup requires the python 'dnspython' library and it is not installed
```