### PR TITLE
Update rust toolchain to 1.79.0

### DIFF
--- a/dockerfiles/ci-unified/Dockerfile
+++ b/dockerfiles/ci-unified/Dockerfile
@@ -83,7 +83,7 @@ RUN pip install yq
 
 ### generic ci ####
 
-ARG RUST_STABLE_VERSION="1.77.0"
+ARG RUST_STABLE_VERSION="1.79.0"
 
 # generic ci | install stable rust
 RUN rustup toolchain install "${RUST_STABLE_VERSION}" --profile minimal && \


### PR DESCRIPTION
Needed for this parity-scale-codec PR: https://github.com/paritytech/parity-scale-codec/pull/615 which uses inline const.