### PR TITLE
Adding /__w directory to tools image

### DIFF
--- a/dockerfiles/tools/Dockerfile
+++ b/dockerfiles/tools/Dockerfile
@@ -34,7 +34,8 @@ RUN set -x \
     && useradd -u 1000 -g 1000 -s /bin/bash -m nonroot \
     && git config --global --add safe.directory '*' \
     && cp /root/.gitconfig /home/nonroot/.gitconfig \
-    && chown nonroot:nonroot /home/nonroot/.gitconfig
+    && chown nonroot:nonroot /home/nonroot/.gitconfig \
+    && mkdir /__w && chown nonroot:nonroot /__w
 
 USER nonroot:nonroot
 CMD ["/bin/bash"]


### PR DESCRIPTION
This (in theory) will allow running GHA in container, without root

see https://github.com/actions/checkout/issues/1014
